### PR TITLE
Remove automatic server downloads, improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Coffee Editor Extension Example
+# Coffee Editor IDE
 An example of how to build the Theia-based applications with the tree-editor-extension.
 The coffee-editor consists of a frontend and a backend.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,76 @@
+# Coffee Editor Extension Example
+An example of how to build the Theia-based applications with the tree-editor-extension.
+The coffee-editor consists of a frontend and a backend.
+
+The frontend is located in the `web/` folder and frontend specific documentation can be found in the [backend README](backend/README.md)
+
+The backend is located in the `backend/` folder and backend specific documentation can be found in the [frontend README](web/README.md)
+
+## Used Projects
+We are relying on a bunch of projects:
+* https://github.com/eclipsesource/jsonforms
+* https://github.com/eclipsesource/graphical-lsp
+* https://github.com/eclipsesource/modelserver
+* https://github.com/eclipsesource/modelserver-theia
+
+If you encounter issues please report them in the corresponding project.
+This project should not contain much code and should mostly consist of 'glue' code to combine the different components.
+
+## Prerequisites
+
+Install [nvm](https://github.com/creationix/nvm#install-script).
+
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+
+Install npm and node.
+
+    nvm install 10
+    nvm use 10
+
+Install yarn.
+
+    npm install -g yarn
+
+Install linux packages (if necessary).
+
+    sudo apt-get install g++-4.8 libsecret-1-dev xvfb libx11-dev libxkbfile-dev
+
+## Getting started
+
+Clone and build the coffee-editor:
+
+    git clone https://github.com/eclipsesource/coffee-editor.git
+    cd coffee-editor
+    ./run.sh -b -c -d -f
+    
+Run the built coffee-editor:
+
+    ./run.sh -r
+
+Open http://localhost:3000 in the browser.
+
+On the `File Menu`, open a project and double click a `.coffee` file. This opens it in a tree master detail editor.
+
+## The build and run script
+The `run.sh` script provides funtionality to build the coffee-editor, download used libraries, and run the IDE.
+Every part step can be executed independently from each other by using the corresponding paramater:
+
+`-b`: Builds the backend services
+
+`-c`: Integrates the built backend artifacts in the coffee-editor IDE
+
+`-d`: Downloads the current version of the Model and GLSP servers. These are not required for building the coffee-editor but are used at runtime
+
+`-f`: Builds the frontend shown in the web browser
+
+`-r`: Runs the coffee-editor and exposes it at http://localhost:3000
+
+## Publishing the coffee-editor-extension
+
+Create a npm user and login to the npm registry, [more on npm publishing](https://docs.npmjs.com/getting-started/publishing-npm-packages).
+
+    npm login
+
+Publish packages with lerna to update versions properly across local packages, [more on publishing with lerna](https://github.com/lerna/lerna#publish).
+
+    npx lerna publish

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,10 @@
+# Coffee Editor Extension Example - Backend
+
+The backend is implemented as an Eclipse product. The custom plugins are located in `plugins/` and `releng/` contains build information like the target platform and the product configuration.
+
+## Build the backend
+There are two ways to build the backend.
+1. Running `./run.sh -b` in the root folder of the coffee-editor ide
+2. Use maven directly and build the project releng/com.eclipsesource.coffee.target
+
+**Note:** To use the newly built backend in the coffee-editor IDE you also need to copy it to the frontend after building it. This can be done with running `./run.sh -c` in the root folder.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,4 +1,4 @@
-# Coffee Editor Extension Example - Backend
+# Coffee Editor IDE - Backend
 
 The backend is implemented as an Eclipse product. The custom plugins are located in `plugins/` and `releng/` contains build information like the target platform and the product configuration.
 

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 echo "$(date +"[%T.%3N]") Evaluate Options... "
 buildBackend='false'
 copyBackend='false'
+downloadServers='false'
 buildFrontend='false'
 runFrontend='false'
 
@@ -11,6 +12,8 @@ while [ "$1" != "" ]; do
     -b | --backend )  buildBackend='true'
                       ;;
     -c | --copy )     copyBackend='true'
+                      ;;
+    -d | --download ) downloadServers='true'
                       ;;
     -f | --frontend ) buildFrontend='true'
                       ;;
@@ -21,6 +24,7 @@ while [ "$1" != "" ]; do
 done
 [[ "$buildBackend" == "true" ]] && echo "  Build Backend (-b)" || echo "  Do not build Backend (-b)"
 [[ "$copyBackend" == "true" ]] && echo "  Copy Backend (-c)" || echo "  Do not copy Backend (-c)"
+[[ "$downloadServers" == "true" ]] && echo "  Download Model & GLSP Servers (-d)" || echo "  Do not download Model & GLSP Servers (-d)"
 [[ "$buildFrontend" == "true" ]] && echo "  Build Frontend (-f)" || echo "  Do not build Frontend (-f)"
 [[ "$runFrontend" == "true" ]] && echo "  Run Frontend (-r)" || echo "  Do not run Frontend (-r)"
 
@@ -50,6 +54,12 @@ if [ "$copyBackend" == "true" ]; then
   rm -r $outputWorkflowDSL && mkdir -p $outputWorkflowDSL && cp -rf $inputWorkflowDSL $outputWorkflowDSL
 
   echo "$(date +"[%T.%3N]") Copy finished."
+fi
+
+if [ "$downloadServers" == "true" ]; then
+  cd ./web/coffee-server/scripts/
+  ./download-server.sh
+  cd ../../../
 fi
 
 if [ "$buildFrontend" == "true" ]; then

--- a/web/README.md
+++ b/web/README.md
@@ -1,4 +1,4 @@
-# Coffee Editor Extension Example - Frontend
+# Coffee Editor IDE - Frontend
 
 This part contains the frontend of the coffee editor IDE shown in the browser.
 

--- a/web/README.md
+++ b/web/README.md
@@ -1,49 +1,8 @@
-# Coffee Editor Extension Example
-An example of how to build the Theia-based applications with the tree-editor-extension.
+# Coffee Editor Extension Example - Frontend
 
-## Used Projects
-We are relying on a bunch of projects:
-* https://github.com/eclipsesource/theia-tree-editor
-* https://github.com/eclipsesource/jsonforms
-* https://github.com/eclipsesource/graphical-lsp
-
-If you encounter issues please report them in the corresponding project.
-This project should not contain much code and should mostly consist of 'glue' code to combine the different components.
-
-## Prerequisites
-
-Install [nvm](https://github.com/creationix/nvm#install-script).
-
-    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-
-Install npm and node.
-
-    nvm install 8
-    nvm use 8
-
-Install yarn.
-
-    npm install -g yarn
-
-## Getting started
-
-    git clone https://github.com/eclipsesource/coffee-editor.git
-    cd coffee-editor
-    ./run.sh -b -c -f
-    
-    git clone git@github.com:eclipsesource/graphical-lsp.git
-    cd graphical-lsp
-Open in Eclipse and start the com.eclipsesource.glsp.example.workflow.ExampleServerLauncher Java class
-    
-    in coffee-editor:
-    ./run.sh -r
-
-Open http://localhost:3000 in the browser.
-
-On the `File Menu`, open a project and right click to a JSON file and select `Open With -> Open With Tree Editor`
+This part contains the frontend of the coffee editor IDE shown in the browser.
 
 ## Developing with the browser example
-
 
 1. Start watching changes on the extension via 
    ```
@@ -72,14 +31,3 @@ On the `File Menu`, open a project and right click to a JSON file and select `Op
    This start the browser app on `http://localhost:3000`
 
 **NOTE**: The browser does not reload automatically whenever you changed something, you need to reload yourself currently.
-
-
-## Publishing coffee-editor-extension
-
-Create a npm user and login to the npm registry, [more on npm publishing](https://docs.npmjs.com/getting-started/publishing-npm-packages).
-
-    npm login
-
-Publish packages with lerna to update versions properly across local packages, [more on publishing with lerna](https://github.com/lerna/lerna#publish).
-
-    npx lerna publish

--- a/web/coffee-server/package.json
+++ b/web/coffee-server/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "prepare": "yarn run clean && yarn run build",
     "clean": "rimraf lib",
-    "build": "tsc && yarn run download-server",
+    "build": "tsc",
     "download-server": "cd ./scripts && ./download-server.sh"
   },
   "theiaExtensions": [


### PR DESCRIPTION
The coffee-server extension no longer automatically downloads the model and GLSP server jars on build. Instead, the run.sh now offers a parameter -d to download the servers.