### PR TITLE
Unify coffee tree editor's icons for tab and file navigator

### DIFF
--- a/web/coffee-editor-extension/src/browser/CoffeeLabelProvider.ts
+++ b/web/coffee-editor-extension/src/browser/CoffeeLabelProvider.ts
@@ -20,7 +20,7 @@ export class CoffeeLabelProviderContribution implements LabelProviderContributio
     }
     
     getIcon(): MaybePromise<string> {
-        return 'database-icon medium-yellow';
+        return 'coffee-icon dark-purple';
     }
     
     getName(uri: URI): string {

--- a/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-tree-editor-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-tree-editor-widget.tsx
@@ -79,7 +79,7 @@ export class JsonFormsTreeEditorWidget extends BaseWidget
     this.title.label = options.uri.path.base;
     this.title.caption = JsonFormsTreeEditorWidget.WIDGET_LABEL;
     this.title.closable = true;
-    this.title.iconClass = "icon machine";
+    this.title.iconClass = "fa coffee-icon dark-purple";
     this.addClass(JsonFormsTreeEditorWidget.Styles.JSONFORMS_TREE_EDITOR_CLASS);
 
     this.contentNode = document.createElement("div");


### PR DESCRIPTION
This is a part of #122