### PR TITLE
Add and remove UI for the tree

### DIFF
--- a/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
@@ -1,10 +1,12 @@
-import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from "@theia/core";
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, Command } from "@theia/core";
 import { ApplicationShell, NavigatableWidgetOpenHandler, OpenerService } from "@theia/core/lib/browser";
 import URI from "@theia/core/lib/common/uri";
 import { inject, injectable } from "inversify";
 
 import { JsonFormsTreeEditorWidget } from "./json-forms-tree-editor/json-forms-tree-editor-widget";
+import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 import {
+  AddCommandHandler,
   JsonFormsTreeCommands,
   JsonFormsTreeContextMenu,
   OpenWorkflowDiagramCommandHandler
@@ -14,9 +16,21 @@ import {
 export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<JsonFormsTreeEditorWidget> implements CommandContribution, MenuContribution {
   @inject(ApplicationShell) protected shell: ApplicationShell;
   @inject(OpenerService) protected opener: OpenerService;
+  @inject(JsonFormsTreeLabelProvider) protected labelProvider: JsonFormsTreeLabelProvider;
 
   readonly id = JsonFormsTreeEditorWidget.WIDGET_ID;
   readonly label = JsonFormsTreeEditorWidget.WIDGET_LABEL;
+  private commandMap: Map<string, Command>;
+
+  /**
+   * @returns maps EClass identifiers to their corresponding add command
+   */
+  private getCommandMap(): Map<string, Command> {
+    if (!this.commandMap) {
+      this.commandMap = JsonFormsTreeCommands.generateAddCommands();
+    }
+    return this.commandMap;
+  }
 
   canHandle(uri: URI): number {
     if (
@@ -31,12 +45,24 @@ export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<J
     commands.registerCommand(
       JsonFormsTreeCommands.OPEN_WORKFLOW_DIAGRAM,
       new OpenWorkflowDiagramCommandHandler(this.shell, this.opener));
+
+      this.getCommandMap().forEach((value, key, _map) => {
+        commands.registerCommand(value, new AddCommandHandler(key));
+      });
   }
 
   registerMenus(menus: MenuModelRegistry): void {
     menus.registerMenuAction(JsonFormsTreeContextMenu.CONTEXT_MENU, {
       commandId: JsonFormsTreeCommands.OPEN_WORKFLOW_DIAGRAM.id,
       label: JsonFormsTreeCommands.OPEN_WORKFLOW_DIAGRAM.label
+    });
+
+    this.getCommandMap().forEach((value, key, _map) => {
+      menus.registerMenuAction(JsonFormsTreeContextMenu.ADD_MENU, {
+        commandId: value.id,
+        label: value.label,
+        icon: this.labelProvider.getIconClass(key)
+      })
     });
   }
 

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
@@ -1,3 +1,4 @@
+
 export namespace CoffeeModel {
     export namespace Type {
         export const AutomaticTask = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask";
@@ -21,5 +22,44 @@ export namespace CoffeeModel {
         export const WaterTank = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//WaterTank";
         export const WeightedFlow = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//WeightedFlow";
         export const Workflow = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow";
+    }
+
+    const components = [
+        Type.Component,
+        Type.Machine,
+        Type.ControlUnit,
+        Type.BrewingUnit,
+        Type.DipTray,
+        Type.WaterTank
+    ];
+
+    // FIXME add all mappings
+    export const childrenMapping: Map<string, ChildrenDescriptor[]> = new Map([
+        [
+            Type.BrewingUnit, [
+                {
+                    property: 'children',
+                    children: components
+                }
+            ]
+        ],
+        [
+            Type.Component, [
+                {
+                    property: 'children',
+                    children: components
+                },
+                {
+                    property: 'workflows',
+                    children: [ Type.Workflow ]
+                }
+            ]
+        ]
+    ]);
+
+
+    export interface ChildrenDescriptor {
+        property: string;
+        children: string[];
     }
 }

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
@@ -1,3 +1,4 @@
+import URI from '@theia/core/lib/common/uri';
 
 export namespace CoffeeModel {
     export namespace Type {
@@ -22,6 +23,10 @@ export namespace CoffeeModel {
         export const WaterTank = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//WaterTank";
         export const WeightedFlow = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//WeightedFlow";
         export const Workflow = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow";
+
+        export function name(type: string): string {
+            return new URI(type).fragment.substring(2);
+        }
     }
 
     const components = [
@@ -33,7 +38,21 @@ export namespace CoffeeModel {
         Type.WaterTank
     ];
 
-    // FIXME add all mappings
+    const nodes = [
+        Type.AutomaticTask,
+        Type.Decision,
+        Type.Fork,
+        Type.Join,
+        Type.ManualTask,
+        Type.Merge
+    ];
+
+    const flows = [
+        Type.Flow,
+        Type.WeightedFlow
+    ];
+
+    /** Maps types to their creatable children */
     export const childrenMapping: Map<string, ChildrenDescriptor[]> = new Map([
         [
             Type.BrewingUnit, [
@@ -51,10 +70,58 @@ export namespace CoffeeModel {
                 },
                 {
                     property: 'workflows',
-                    children: [ Type.Workflow ]
+                    children: [Type.Workflow]
                 }
             ]
-        ]
+        ],
+        [
+            Type.ControlUnit, [
+                {
+                    property: 'children',
+                    children: components
+                }
+            ]
+        ],
+        [
+            Type.DipTray, [
+                {
+                    property: 'children',
+                    children: components
+                }
+            ]
+        ],
+        [
+            Type.Machine, [
+                {
+                    property: 'children',
+                    children: components
+                },
+                {
+                    property: 'workflows',
+                    children: [Type.Workflow]
+                }
+            ]
+        ],
+        [
+            Type.WaterTank, [
+                {
+                    property: 'children',
+                    children: components
+                }
+            ]
+        ],
+        [
+            Type.Workflow, [
+                {
+                    property: 'flows',
+                    children: flows
+                },
+                {
+                    property: 'nodes',
+                    children: nodes
+                }
+            ]
+        ],
     ]);
 
 

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-label-provider.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-label-provider.ts
@@ -36,14 +36,15 @@ const UNKNOWN_ICON = 'fa-question-circle ' + DEFAULT_COLOR;
 @injectable()
 export class JsonFormsTreeLabelProvider {
 
-  public getIconClass(node: TreeNode): string {
-    if (JsonFormsTree.Node.is(node)) {
-      const iconClass = ICON_CLASSES.get(node.jsonforms.type);
-      if (iconClass !== undefined) {
-        return 'fa ' + iconClass;
-      }
+  public getIconClass(node: TreeNode | string): string {
+    var iconClass: string;
+    if (typeof node === "string") {
+      iconClass =  ICON_CLASSES.get(node);
+    } else if (JsonFormsTree.Node.is(node)){
+      iconClass = ICON_CLASSES.get(node.jsonforms.type);
     }
-    return 'far ' + UNKNOWN_ICON;
+
+    return iconClass ? 'fa ' + iconClass : 'far ' + UNKNOWN_ICON;
   }
 
   public getName(data: any): string {

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
@@ -24,6 +24,7 @@ export namespace JsonFormsTree {
     name: string;
     jsonforms: {
       type: string;
+      property: string;
       index?: string;
       data: any;
     };

--- a/web/coffee-editor-extension/src/browser/style/index.css
+++ b/web/coffee-editor-extension/src/browser/style/index.css
@@ -36,3 +36,15 @@ button[type='button'] {padding:0}
 .tree-class {
   overflow-y: scroll;
 }
+
+.json-forms-tree .node-buttons {
+  visibility: hidden;
+}
+
+.json-forms-tree .node-button {
+  margin-left: 5px;
+}
+
+.json-forms-tree .theia-TreeNode:hover .node-buttons {
+  visibility: inherit;
+}


### PR DESCRIPTION
Adds the UI for the add and remove functionality of #116. However, the add and remove are not implemented, yet.

* Add remove and add buttons that are visible on hovering a tree item
* Add remove handler opening a dialog to confirm the removal.
* Add generation of add commands and menu contributions based on the eclass to creatable children mapping
* Clicking the add button shows a context menu
* The add handler has access to the tree node which the add was invoked for