### PR TITLE
Lint coffee editor expansion

### DIFF
--- a/web/coffee-editor-extension/package.json
+++ b/web/coffee-editor-extension/package.json
@@ -17,13 +17,15 @@
     "@material-ui/core": "^4.0.1",
     "@material-ui/icons": "^4.0.1",
     "@theia/core": "0.7.1",
+    "@theia/filesystem": "0.7.1",
     "@theia/workspace": "0.7.1",
     "material-ui-pickers": "^2.2.4",
     "react": "^16.4.0",
     "react-dom": "^16.4.0",
     "react-redux": "^6.0.0",
     "recompose": "^0.27.1",
-    "redux": "^3.7.2"
+    "redux": "^3.7.2",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "rimraf": "latest",

--- a/web/coffee-editor-extension/src/browser/CoffeeLabelProvider.ts
+++ b/web/coffee-editor-extension/src/browser/CoffeeLabelProvider.ts
@@ -1,32 +1,48 @@
-import { LabelProviderContribution } from "@theia/core/lib/browser";
-import { FileStat } from "@theia/filesystem/lib/common";
-import URI from "@theia/core/lib/common/uri";
-import { MaybePromise } from "@theia/core";
-import { injectable } from "inversify";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import { LabelProviderContribution } from '@theia/core/lib/browser';
+import { FileStat } from '@theia/filesystem/lib/common';
+import URI from '@theia/core/lib/common/uri';
+import { MaybePromise } from '@theia/core';
+import { injectable } from 'inversify';
 
 @injectable()
-export class CoffeeLabelProviderContribution implements LabelProviderContribution{
+export class CoffeeLabelProviderContribution implements LabelProviderContribution {
     canHandle(uri: object): number {
         let toCheck = uri;
-        if(FileStat.is(toCheck)){
+        if (FileStat.is(toCheck)) {
           toCheck = new URI(toCheck.uri);
         }
         if (toCheck instanceof URI) {
-            if(toCheck.path.ext === '.coffee'){
+            if (toCheck.path.ext === '.coffee') {
               return 1000;
             }
         }
         return 0;
     }
-    
+
     getIcon(): MaybePromise<string> {
         return 'coffee-icon dark-purple';
     }
-    
+
     getName(uri: URI): string {
         return uri.displayName;
     }
-    
+
     getLongName(uri: URI): string {
         return uri.path.toString();
     }

--- a/web/coffee-editor-extension/src/browser/CoffeeLabelProvider.ts
+++ b/web/coffee-editor-extension/src/browser/CoffeeLabelProvider.ts
@@ -13,11 +13,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
-import { LabelProviderContribution } from '@theia/core/lib/browser';
-import { FileStat } from '@theia/filesystem/lib/common';
-import URI from '@theia/core/lib/common/uri';
 import { MaybePromise } from '@theia/core';
+import { LabelProviderContribution } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { FileStat } from '@theia/filesystem/lib/common';
 import { injectable } from 'inversify';
 
 @injectable()
@@ -25,11 +24,11 @@ export class CoffeeLabelProviderContribution implements LabelProviderContributio
     canHandle(uri: object): number {
         let toCheck = uri;
         if (FileStat.is(toCheck)) {
-          toCheck = new URI(toCheck.uri);
+            toCheck = new URI(toCheck.uri);
         }
         if (toCheck instanceof URI) {
             if (toCheck.path.ext === '.coffee') {
-              return 1000;
+                return 1000;
             }
         }
         return 0;

--- a/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
@@ -1,21 +1,37 @@
-import "../../src/browser/style/index.css";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 
-import { CommandContribution, MenuContribution } from "@theia/core";
-import { LabelProviderContribution, NavigatableWidgetOptions, OpenHandler, WidgetFactory } from "@theia/core/lib/browser";
-import URI from "@theia/core/lib/common/uri";
-import { ContainerModule } from "inversify";
+import '../../src/browser/style/index.css';
 
-import { CoffeeTreeEditorContribution } from "./coffee-editor-tree-contribution";
-import { CoffeeLabelProviderContribution } from "./CoffeeLabelProvider";
+import { CommandContribution, MenuContribution } from '@theia/core';
+import { LabelProviderContribution, NavigatableWidgetOptions, OpenHandler, WidgetFactory } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { ContainerModule } from 'inversify';
+
+import { CoffeeTreeEditorContribution } from './coffee-editor-tree-contribution';
+import { CoffeeLabelProviderContribution } from './CoffeeLabelProvider';
 import {
   JsonFormsTreeEditorWidget,
   JsonFormsTreeEditorWidgetOptions
-} from "./json-forms-tree-editor/json-forms-tree-editor-widget";
-import { createJsonFormsTreeWidget } from "./json-forms-tree/json-forms-tree-container";
-import { JsonFormsTreeWidget } from "./json-forms-tree/json-forms-tree-widget";
-import { JSONFormsWidget } from "./json-forms-tree-editor/json-forms-widget";
+} from './json-forms-tree-editor/json-forms-tree-editor-widget';
+import { createJsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-container';
+import { JsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-widget';
+import { JSONFormsWidget } from './json-forms-tree-editor/json-forms-widget';
 
-import { JsonFormsTreeLabelProvider } from "./json-forms-tree/json-forms-tree-label-provider";
+import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 export default new ContainerModule(bind => {
   bind(LabelProviderContribution).to(CoffeeLabelProviderContribution);
   bind(JsonFormsTreeWidget).toDynamicValue(context =>

--- a/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 import '../../src/browser/style/index.css';
 
 import { CommandContribution, MenuContribution } from '@theia/core';
@@ -25,13 +24,13 @@ import { CoffeeTreeEditorContribution } from './coffee-editor-tree-contribution'
 import { CoffeeLabelProviderContribution } from './CoffeeLabelProvider';
 import {
   JsonFormsTreeEditorWidget,
-  JsonFormsTreeEditorWidgetOptions
+  JsonFormsTreeEditorWidgetOptions,
 } from './json-forms-tree-editor/json-forms-tree-editor-widget';
-import { createJsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-container';
-import { JsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-widget';
 import { JSONFormsWidget } from './json-forms-tree-editor/json-forms-widget';
-
+import { createJsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-container';
 import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
+import { JsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-widget';
+
 export default new ContainerModule(bind => {
   bind(LabelProviderContribution).to(CoffeeLabelProviderContribution);
   bind(JsonFormsTreeWidget).toDynamicValue(context =>

--- a/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
@@ -13,20 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
-import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, Command } from '@theia/core';
+import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry } from '@theia/core';
 import { ApplicationShell, NavigatableWidgetOpenHandler, OpenerService } from '@theia/core/lib/browser';
 import URI from '@theia/core/lib/common/uri';
 import { inject, injectable } from 'inversify';
 
 import { JsonFormsTreeEditorWidget } from './json-forms-tree-editor/json-forms-tree-editor-widget';
-import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 import {
   AddCommandHandler,
   JsonFormsTreeCommands,
   JsonFormsTreeContextMenu,
-  OpenWorkflowDiagramCommandHandler
+  OpenWorkflowDiagramCommandHandler,
 } from './json-forms-tree/json-forms-tree-container';
+import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 
 @injectable()
 export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<JsonFormsTreeEditorWidget> implements CommandContribution, MenuContribution {
@@ -62,9 +61,9 @@ export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<J
       JsonFormsTreeCommands.OPEN_WORKFLOW_DIAGRAM,
       new OpenWorkflowDiagramCommandHandler(this.shell, this.opener));
 
-      this.getCommandMap().forEach((value, key, _map) => {
-        commands.registerCommand(value, new AddCommandHandler(key));
-      });
+    this.getCommandMap().forEach((value, key, _map) => {
+      commands.registerCommand(value, new AddCommandHandler(key));
+    });
   }
 
   registerMenus(menus: MenuModelRegistry): void {

--- a/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
@@ -1,16 +1,32 @@
-import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, Command } from "@theia/core";
-import { ApplicationShell, NavigatableWidgetOpenHandler, OpenerService } from "@theia/core/lib/browser";
-import URI from "@theia/core/lib/common/uri";
-import { inject, injectable } from "inversify";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 
-import { JsonFormsTreeEditorWidget } from "./json-forms-tree-editor/json-forms-tree-editor-widget";
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, Command } from '@theia/core';
+import { ApplicationShell, NavigatableWidgetOpenHandler, OpenerService } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { inject, injectable } from 'inversify';
+
+import { JsonFormsTreeEditorWidget } from './json-forms-tree-editor/json-forms-tree-editor-widget';
 import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 import {
   AddCommandHandler,
   JsonFormsTreeCommands,
   JsonFormsTreeContextMenu,
   OpenWorkflowDiagramCommandHandler
-} from "./json-forms-tree/json-forms-tree-container";
+} from './json-forms-tree/json-forms-tree-container';
 
 @injectable()
 export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<JsonFormsTreeEditorWidget> implements CommandContribution, MenuContribution {
@@ -34,7 +50,7 @@ export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<J
 
   canHandle(uri: URI): number {
     if (
-      uri.path.ext === ".coffee"
+      uri.path.ext === '.coffee'
     ) {
       return 1000;
     }
@@ -62,7 +78,7 @@ export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<J
         commandId: value.id,
         label: value.label,
         icon: this.labelProvider.getIconClass(key)
-      })
+      });
     });
   }
 

--- a/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-tree-editor-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-tree-editor-widget.tsx
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 import { ModelServerClient } from '@modelserver/theia/lib/common';
 import { BaseWidget, Message, Navigatable, Saveable, SplitPanel, Widget } from '@theia/core/lib/browser';
 import { Emitter, Event, ILogger } from '@theia/core/lib/common';

--- a/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-tree-editor-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-tree-editor-widget.tsx
@@ -1,15 +1,31 @@
-import { ModelServerClient } from "@modelserver/theia/lib/common";
-import { BaseWidget, Message, Navigatable, Saveable, SplitPanel, Widget } from "@theia/core/lib/browser";
-import { Emitter, Event, ILogger } from "@theia/core/lib/common";
-import URI from "@theia/core/lib/common/uri";
-import { WorkspaceService } from "@theia/workspace/lib/browser/workspace-service";
-import { inject, injectable } from "inversify";
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 
-import { JsonFormsTree } from "../json-forms-tree/json-forms-tree";
-import { JsonFormsTreeWidget } from "../json-forms-tree/json-forms-tree-widget";
-import { JSONFormsWidget } from "./json-forms-widget";
+import { ModelServerClient } from '@modelserver/theia/lib/common';
+import { BaseWidget, Message, Navigatable, Saveable, SplitPanel, Widget } from '@theia/core/lib/browser';
+import { Emitter, Event, ILogger } from '@theia/core/lib/common';
+import URI from '@theia/core/lib/common/uri';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { inject, injectable } from 'inversify';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import { JsonFormsTree } from '../json-forms-tree/json-forms-tree';
+import { JsonFormsTreeWidget } from '../json-forms-tree/json-forms-tree-widget';
+import { JSONFormsWidget } from './json-forms-widget';
 
 export const JsonFormsTreeEditorWidgetOptions = Symbol(
   'JsonFormsTreeEditorWidgetOptions'

--- a/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-widget.tsx
@@ -1,17 +1,33 @@
-import { Actions, jsonformsReducer, JsonFormsState } from "@jsonforms/core";
-import { materialCells, materialRenderers } from "@jsonforms/material-renderers";
-import { JsonFormsDispatch, JsonFormsReduxContext } from "@jsonforms/react";
-import { Emitter, Event, ILogger } from "@theia/core";
-import { BaseWidget, Message } from "@theia/core/lib/browser";
-import { inject, injectable } from "inversify";
-import * as React from "react";
-import * as ReactDOM from "react-dom";
-import { Provider } from "react-redux";
-import { combineReducers, createStore } from "redux";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 
-import { CoffeeModel } from "../json-forms-tree/coffee-model";
-import { JsonFormsTree } from "../json-forms-tree/json-forms-tree";
-import { brewingView, coffeeSchema, controlUnitView, machineView } from "../models/coffee-schemas";
+import { Actions, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
+import { materialCells, materialRenderers } from '@jsonforms/material-renderers';
+import { JsonFormsDispatch, JsonFormsReduxContext } from '@jsonforms/react';
+import { Emitter, Event, ILogger } from '@theia/core';
+import { BaseWidget, Message } from '@theia/core/lib/browser';
+import { inject, injectable } from 'inversify';
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import { CoffeeModel } from '../json-forms-tree/coffee-model';
+import { JsonFormsTree } from '../json-forms-tree/json-forms-tree';
+import { brewingView, coffeeSchema, controlUnitView, machineView } from '../models/coffee-schemas';
 
 @injectable()
 export class JSONFormsWidget extends BaseWidget {
@@ -28,7 +44,7 @@ export class JSONFormsWidget extends BaseWidget {
     this.toDispose.push(this.changeEmitter);
     this.store.subscribe(() => {
       this.changeEmitter.fire(this.store.getState().jsonforms.core.data);
-    })
+    });
     this.renderEmptyForms();
   }
   get onChange(): Event<Readonly<any>> {
@@ -61,7 +77,7 @@ export class JSONFormsWidget extends BaseWidget {
         this.getUiSchemaForNode(this.selectedNode),
         {
           refParserOptions: {
-            dereference: { circular: "ignore" }
+            dereference: { circular: 'ignore' }
           }
         }
       )
@@ -69,7 +85,7 @@ export class JSONFormsWidget extends BaseWidget {
     this.renderForms();
   }
   protected getSchemaForNode(node: JsonFormsTree.Node) {
-    let schema = this.getSchemaForType(node.jsonforms.type);
+    const schema = this.getSchemaForType(node.jsonforms.type);
     if (schema) {
       return schema;
     }
@@ -80,15 +96,15 @@ export class JSONFormsWidget extends BaseWidget {
     return undefined;
   }
   protected getUiSchemaForNode(node: JsonFormsTree.Node) {
-    let schema = this.getUiSchemaForType(node.jsonforms.type);
+    const schema = this.getUiSchemaForType(node.jsonforms.type);
     if (schema) {
       return schema;
     }
     // there is no type, try to guess
     if (node.jsonforms.data.nodes) {
       return {
-        type: "Label",
-        text: "Workflow"
+        type: 'Label',
+        text: 'Workflow'
       };
     }
     return undefined;

--- a/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree-editor/json-forms-widget.tsx
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 import { Actions, jsonformsReducer, JsonFormsState } from '@jsonforms/core';
 import { materialCells, materialRenderers } from '@jsonforms/material-renderers';
 import { JsonFormsDispatch, JsonFormsReduxContext } from '@jsonforms/react';

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 import URI from '@theia/core/lib/common/uri';
 
 export namespace CoffeeModel {

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/coffee-model.ts
@@ -1,28 +1,44 @@
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 import URI from '@theia/core/lib/common/uri';
 
 export namespace CoffeeModel {
     export namespace Type {
-        export const AutomaticTask = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask";
-        export const BrewingUnit = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit";
-        export const Component = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Component";
-        export const ControlUnit = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit";
-        export const Decision = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Decision";
-        export const Dimension = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Dimension";
-        export const DipTray = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//DipTray";
-        export const Display = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Display";
-        export const Flow = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Flow";
-        export const Fork = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Fork";
-        export const Join = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Join";
-        export const Machine = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine";
-        export const ManualTask = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//ManualTask";
-        export const Merge = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Merge";
-        export const Node = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Node";
-        export const Processor = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Processor";
-        export const RAM = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//RAM";
-        export const Task = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Task";
-        export const WaterTank = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//WaterTank";
-        export const WeightedFlow = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//WeightedFlow";
-        export const Workflow = "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow";
+        export const AutomaticTask = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask';
+        export const BrewingUnit = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit';
+        export const Component = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Component';
+        export const ControlUnit = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit';
+        export const Decision = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Decision';
+        export const Dimension = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Dimension';
+        export const DipTray = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//DipTray';
+        export const Display = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Display';
+        export const Flow = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Flow';
+        export const Fork = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Fork';
+        export const Join = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Join';
+        export const Machine = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine';
+        export const ManualTask = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ManualTask';
+        export const Merge = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Merge';
+        export const Node = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Node';
+        export const Processor = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Processor';
+        export const RAM = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//RAM';
+        export const Task = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Task';
+        export const WaterTank = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//WaterTank';
+        export const WeightedFlow = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//WeightedFlow';
+        export const Workflow = 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Workflow';
 
         export function name(type: string): string {
             return new URI(type).fragment.substring(2);
@@ -123,7 +139,6 @@ export namespace CoffeeModel {
             ]
         ],
     ]);
-
 
     export interface ChildrenDescriptor {
         property: string;

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-container.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-container.ts
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 import { Command, CommandHandler, MenuPath } from '@theia/core';
 import { ApplicationShell, OpenerService } from '@theia/core/lib/browser';
 import { createTreeContainer, defaultTreeProps, TreeProps, TreeWidget } from '@theia/core/lib/browser/tree';

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-container.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-container.ts
@@ -1,13 +1,29 @@
-import { Command, CommandHandler, MenuPath } from "@theia/core";
-import { ApplicationShell, OpenerService } from "@theia/core/lib/browser";
-import { createTreeContainer, defaultTreeProps, TreeProps, TreeWidget } from "@theia/core/lib/browser/tree";
-import URI from "@theia/core/lib/common/uri";
-import { Container, interfaces } from "inversify";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 
-import { JsonFormsTreeEditorWidget } from "../json-forms-tree-editor/json-forms-tree-editor-widget";
-import { CoffeeModel } from "./coffee-model";
-import { JsonFormsTree } from "./json-forms-tree";
-import { JsonFormsTreeWidget } from "./json-forms-tree-widget";
+import { Command, CommandHandler, MenuPath } from '@theia/core';
+import { ApplicationShell, OpenerService } from '@theia/core/lib/browser';
+import { createTreeContainer, defaultTreeProps, TreeProps, TreeWidget } from '@theia/core/lib/browser/tree';
+import URI from '@theia/core/lib/common/uri';
+import { Container, interfaces } from 'inversify';
+
+import { JsonFormsTreeEditorWidget } from '../json-forms-tree-editor/json-forms-tree-editor-widget';
+import { CoffeeModel } from './coffee-model';
+import { JsonFormsTree } from './json-forms-tree';
+import { JsonFormsTreeWidget } from './json-forms-tree-widget';
 
 export namespace JsonFormsTreeContextMenu {
   export const CONTEXT_MENU: MenuPath = ['json-forms-tree-context-menu'];
@@ -31,17 +47,17 @@ export namespace JsonFormsTreeCommands {
       // unify by adding to set
       .reduce((acc, val) => acc.add(val), new Set<string>());
 
-      // Create a command for every eclass which can be added to at least one model object
-      const commandMap: Map<string, Command> = new Map();
-      Array.from(creatableTypes).forEach(eclass => {
-        const name = CoffeeModel.Type.name(eclass);
-        commandMap.set(eclass, {
-          id: 'json-forms-tree.add.' + name,
-          label: name
-        });
+    // Create a command for every eclass which can be added to at least one model object
+    const commandMap: Map<string, Command> = new Map();
+    Array.from(creatableTypes).forEach(eclass => {
+      const name = CoffeeModel.Type.name(eclass);
+      commandMap.set(eclass, {
+        id: 'json-forms-tree.add.' + name,
+        label: name
       });
+    });
 
-      return commandMap;
+    return commandMap;
   }
 }
 
@@ -52,8 +68,8 @@ export interface JsonFormsTreeAnchor {
 }
 
 export class AddCommandHandler implements CommandHandler {
-  
-  constructor (readonly eclass: string) {
+
+  constructor(readonly eclass: string) {
   }
 
   execute(treeAnchor: JsonFormsTreeAnchor) {
@@ -75,7 +91,7 @@ export class OpenWorkflowDiagramCommandHandler implements CommandHandler {
     protected readonly openerService: OpenerService) {
   }
 
-  execute(...args: any[]) {
+  execute() {
     const editorWidget = this.getTreeEditorWidget();
     if (editorWidget) {
       const workflowNode = this.getSelectedWorkflow(editorWidget);
@@ -86,7 +102,7 @@ export class OpenWorkflowDiagramCommandHandler implements CommandHandler {
     }
   }
 
-  isVisible?(...args: any[]): boolean {
+  isVisible(): boolean {
     return this.getSelectedWorkflow(this.getTreeEditorWidget()) !== undefined;
   }
 
@@ -107,7 +123,7 @@ export class OpenWorkflowDiagramCommandHandler implements CommandHandler {
 
   getNotationUri(widget: JsonFormsTreeEditorWidget): URI {
     const coffeeUri = widget.uri();
-    const coffeeNotationUri = coffeeUri.parent.resolve(coffeeUri.displayName + "notation");
+    const coffeeNotationUri = coffeeUri.parent.resolve(coffeeUri.displayName + 'notation');
     return coffeeNotationUri;
   }
 
@@ -116,7 +132,7 @@ export class OpenWorkflowDiagramCommandHandler implements CommandHandler {
       serverOptions: {
         workflowIndex: node.jsonforms.index
       }
-    }
+    };
   }
 }
 

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-label-provider.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-label-provider.ts
@@ -1,9 +1,24 @@
-import { CoffeeModel } from "./coffee-model";
-import { injectable } from "inversify";
-import { JsonFormsTree } from "./json-forms-tree";
-import URI from "@theia/core/lib/common/uri";
-import { TreeNode } from "@theia/core/lib/browser/tree/tree";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
 
+import { CoffeeModel } from './coffee-model';
+import { injectable } from 'inversify';
+import { JsonFormsTree } from './json-forms-tree';
+import URI from '@theia/core/lib/common/uri';
+import { TreeNode } from '@theia/core/lib/browser/tree/tree';
 
 const DEFAULT_COLOR = 'black';
 
@@ -37,10 +52,10 @@ const UNKNOWN_ICON = 'fa-question-circle ' + DEFAULT_COLOR;
 export class JsonFormsTreeLabelProvider {
 
   public getIconClass(node: TreeNode | string): string {
-    var iconClass: string;
-    if (typeof node === "string") {
+    let iconClass: string;
+    if (typeof node === 'string') {
       iconClass =  ICON_CLASSES.get(node);
-    } else if (JsonFormsTree.Node.is(node)){
+    } else if (JsonFormsTree.Node.is(node)) {
       iconClass = ICON_CLASSES.get(node.jsonforms.type);
     }
 
@@ -50,15 +65,15 @@ export class JsonFormsTreeLabelProvider {
   public getName(data: any): string {
     if (data.eClass) {
       switch (data.eClass) {
-        case "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Task":
-        case "http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask":
-        case "http://www.eclipsesource.com/modelserver/example/coffeemodel#//ManualTask":
-        case "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine":
+        case 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Task':
+        case 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask':
+        case 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ManualTask':
+        case 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine':
           return data.name;
         default:
           // TODO query title of schema
           const fragment = new URI(data.eClass).fragment;
-          if (fragment.startsWith("//")) {
+          if (fragment.startsWith('//')) {
             return fragment.substring(2);
           }
           return fragment;
@@ -66,7 +81,7 @@ export class JsonFormsTreeLabelProvider {
     }
     // guess
     if (data.nodes) {
-      return "Workflow";
+      return 'Workflow';
     }
     return undefined;
   }

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-label-provider.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-label-provider.ts
@@ -13,39 +13,39 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
+import { TreeNode } from '@theia/core/lib/browser/tree/tree';
+import URI from '@theia/core/lib/common/uri';
+import { injectable } from 'inversify';
 
 import { CoffeeModel } from './coffee-model';
-import { injectable } from 'inversify';
 import { JsonFormsTree } from './json-forms-tree';
-import URI from '@theia/core/lib/common/uri';
-import { TreeNode } from '@theia/core/lib/browser/tree/tree';
 
 const DEFAULT_COLOR = 'black';
 
 const ICON_CLASSES: Map<string, string> = new Map([
-  [ CoffeeModel.Type.AutomaticTask, 'fa-cog ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.BrewingUnit, 'fa-burn ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Component, 'fa-cube ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.ControlUnit, 'fa-server ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Decision, 'fa-code-branch fa-rotate-90 ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Dimension, 'fa-arrows-alt ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.DipTray, 'fa-inbox ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Display, 'fa-tv ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Flow, 'fa-exchange-alt ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Fork, 'fa-code-branch fa-rotate-90 ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Join, 'fa-code-branch fa-rotate-270 ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Machine, 'fa-cogs ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.ManualTask, 'fa-wrench ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Merge, 'fa-code-branch fa-rotate-270 ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Node, 'fa-circle ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Processor, 'fa-microchip ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.RAM, 'fa-memory ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.Task, 'fa-tasks ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.WaterTank, 'fa-water ' + DEFAULT_COLOR],
-  [ CoffeeModel.Type.WeightedFlow, 'fa-exchange-alt light-orange'],
+  [CoffeeModel.Type.AutomaticTask, 'fa-cog ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.BrewingUnit, 'fa-burn ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Component, 'fa-cube ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.ControlUnit, 'fa-server ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Decision, 'fa-code-branch fa-rotate-90 ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Dimension, 'fa-arrows-alt ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.DipTray, 'fa-inbox ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Display, 'fa-tv ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Flow, 'fa-exchange-alt ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Fork, 'fa-code-branch fa-rotate-90 ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Join, 'fa-code-branch fa-rotate-270 ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Machine, 'fa-cogs ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.ManualTask, 'fa-wrench ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Merge, 'fa-code-branch fa-rotate-270 ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Node, 'fa-circle ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Processor, 'fa-microchip ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.RAM, 'fa-memory ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.Task, 'fa-tasks ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.WaterTank, 'fa-water ' + DEFAULT_COLOR],
+  [CoffeeModel.Type.WeightedFlow, 'fa-exchange-alt light-orange'],
 ]);
 
- /* Icon for unknown types */
+/* Icon for unknown types */
 const UNKNOWN_ICON = 'fa-question-circle ' + DEFAULT_COLOR;
 
 @injectable()
@@ -54,7 +54,7 @@ export class JsonFormsTreeLabelProvider {
   public getIconClass(node: TreeNode | string): string {
     let iconClass: string;
     if (typeof node === 'string') {
-      iconClass =  ICON_CLASSES.get(node);
+      iconClass = ICON_CLASSES.get(node);
     } else if (JsonFormsTree.Node.is(node)) {
       iconClass = ICON_CLASSES.get(node.jsonforms.type);
     }

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-widget.tsx
@@ -1,15 +1,31 @@
-import { Emitter, ILogger } from "@theia/core";
-import { ExpandableTreeNode, TreeModel, ConfirmDialog } from "@theia/core/lib/browser";
-import { ContextMenuRenderer } from "@theia/core/lib/browser/context-menu-renderer";
-import { TreeNode } from "@theia/core/lib/browser/tree/tree";
-import { TreeProps, TreeWidget, NodeProps } from "@theia/core/lib/browser/tree/tree-widget";
-import { inject, injectable, postConstruct } from "inversify";
-import * as React from "react";
-import { v4 } from "uuid";
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+import { Emitter, ILogger } from '@theia/core';
+import { ExpandableTreeNode, TreeModel, ConfirmDialog } from '@theia/core/lib/browser';
+import { ContextMenuRenderer } from '@theia/core/lib/browser/context-menu-renderer';
+import { TreeNode } from '@theia/core/lib/browser/tree/tree';
+import { TreeProps, TreeWidget, NodeProps } from '@theia/core/lib/browser/tree/tree-widget';
+import { inject, injectable, postConstruct } from 'inversify';
+import * as React from 'react';
+import { v4 } from 'uuid';
 
 import { CoffeeModel } from './coffee-model';
-import { JsonFormsTree } from "./json-forms-tree";
-import { JsonFormsTreeLabelProvider } from "./json-forms-tree-label-provider";
+import { JsonFormsTree } from './json-forms-tree';
+import { JsonFormsTreeLabelProvider } from './json-forms-tree-label-provider';
 import { JsonFormsTreeContextMenu, JsonFormsTreeAnchor } from './json-forms-tree-container';
 
 @injectable()
@@ -49,7 +65,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
   protected init() {
     super.init();
 
-    this.addClass("tree-container");
+    this.addClass('tree-container');
 
     this.toDispose.push(this.onTreeWidgetSelectionEmitter);
     this.toDispose.push(
@@ -64,7 +80,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
   /** Overrides method in TreeWidget */
   protected handleClickEvent(node: TreeNode | undefined, event: React.MouseEvent<HTMLElement>): void {
     const x = event.target as HTMLElement;
-    if (x.classList.contains("node-button")) {
+    if (x.classList.contains('node-button')) {
       // Don't do anything because the event is handled in the button's handler
       return;
     }
@@ -84,9 +100,9 @@ export class JsonFormsTreeWidget extends TreeWidget {
     const addPlus = this.hasCreatableChildren(node.jsonforms.type);
     return (<React.Fragment>
       {deco}
-      <div className="node-buttons">
-        {addPlus ? <div className="node-button far fa-plus-square" onClick={this.createAddHandler(node)} /> : ''}
-        <div className="node-button far fa-minus-square" onClickCapture={this.createRemoveHandler(node)} />
+      <div className='node-buttons'>
+        {addPlus ? <div className='node-button far fa-plus-square' onClick={this.createAddHandler(node)} /> : ''}
+        <div className='node-button far fa-minus-square' onClickCapture={this.createRemoveHandler(node)} />
       </div>
     </React.Fragment>);
   }
@@ -100,7 +116,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
    * @param node The tree node to create a remove handler for
    */
   private createRemoveHandler(node: JsonFormsTree.Node): (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void {
-    return _event => {
+    return event => {
       event.stopPropagation();
       const dialog = new ConfirmDialog({
         title: 'Delete Node?',
@@ -109,7 +125,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
       dialog.open().then(remove => {
         if (remove && node.parent && node.parent && JsonFormsTree.Node.is(node.parent)) {
           const prop = node.jsonforms.property;
-          console.log("Remove node " + node.name + " from parent property " + prop);
+          console.log('Remove node ' + node.name + ' from parent property ' + prop);
           if (node.jsonforms.index) {
             // multi ref
             // create remove command
@@ -120,7 +136,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
           // TODO send command to model server
         }
       });
-    }
+    };
   }
 
   private createAddHandler(node: JsonFormsTree.Node): (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void {
@@ -131,7 +147,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
         node: node
       };
       this.contextMenuRenderer.render(JsonFormsTreeContextMenu.ADD_MENU, treeAnchor);
-    }
+    };
   }
 
   public async setData(data: any) {
@@ -151,7 +167,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
     }
   }
 
-  get onSelectionChange(): import("@theia/core").Event<readonly Readonly<JsonFormsTree.Node>[]> {
+  get onSelectionChange(): import('@theia/core').Event<readonly Readonly<JsonFormsTree.Node>[]> {
     return this.onTreeWidgetSelectionEmitter.event;
   }
 
@@ -174,7 +190,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
 
   protected defaultNode(): Pick<
     JsonFormsTree.Node,
-    "id" | "expanded" | "selected" | "parent" | "decorationData" | "children"
+    'id' | 'expanded' | 'selected' | 'parent' | 'decorationData' | 'children'
   > {
     return {
       id: v4(),
@@ -213,7 +229,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
   ): JsonFormsTree.Node {
     if (!currentData) {
       // sanity check
-      this.logger.warn("mapData called without data");
+      this.logger.warn('mapData called without data');
       return undefined;
     }
     const node = {
@@ -235,25 +251,25 @@ export class JsonFormsTreeWidget extends TreeWidget {
     if (currentData.children) {
       // component types
       currentData.children.forEach((element, idx) => {
-        this.mapData(element, node, "children", undefined, idx);
+        this.mapData(element, node, 'children', undefined, idx);
       });
     }
     if (currentData.workflows) {
       // machine type
       currentData.workflows.forEach((element, idx) => {
-        this.mapData(element, node, "workflows", CoffeeModel.Type.Workflow, idx);
+        this.mapData(element, node, 'workflows', CoffeeModel.Type.Workflow, idx);
       });
     }
     if (currentData.nodes) {
       // workflow type
       currentData.nodes.forEach((element, idx) => {
-        this.mapData(element, node, "nodes", undefined, idx);
+        this.mapData(element, node, 'nodes', undefined, idx);
       });
     }
     if (currentData.flows) {
       // workflow type
       currentData.flows.forEach((element, idx) => {
-        this.mapData(element, node, "flows", undefined, idx);
+        this.mapData(element, node, 'flows', undefined, idx);
       });
     }
     return node;
@@ -295,13 +311,13 @@ export class JsonFormsTreeWidget extends TreeWidget {
 }
 
 export namespace JsonFormsTreeWidget {
-  export const WIDGET_ID = "json-forms-tree";
-  export const WIDGET_LABEL = "JSONForms Tree";
+  export const WIDGET_ID = 'json-forms-tree';
+  export const WIDGET_LABEL = 'JSONForms Tree';
 
   /**
    * CSS styles for the `JSONForms Hierarchy` widget.
    */
   export namespace Styles {
-    export const JSONFORMS_TREE_CLASS = "json-forms-tree";
+    export const JSONFORMS_TREE_CLASS = 'json-forms-tree';
   }
 }

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-widget.tsx
@@ -13,20 +13,19 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 import { Emitter, ILogger } from '@theia/core';
-import { ExpandableTreeNode, TreeModel, ConfirmDialog } from '@theia/core/lib/browser';
+import { ConfirmDialog, ExpandableTreeNode, TreeModel } from '@theia/core/lib/browser';
 import { ContextMenuRenderer } from '@theia/core/lib/browser/context-menu-renderer';
 import { TreeNode } from '@theia/core/lib/browser/tree/tree';
-import { TreeProps, TreeWidget, NodeProps } from '@theia/core/lib/browser/tree/tree-widget';
+import { NodeProps, TreeProps, TreeWidget } from '@theia/core/lib/browser/tree/tree-widget';
 import { inject, injectable, postConstruct } from 'inversify';
 import * as React from 'react';
 import { v4 } from 'uuid';
 
 import { CoffeeModel } from './coffee-model';
 import { JsonFormsTree } from './json-forms-tree';
+import { JsonFormsTreeAnchor, JsonFormsTreeContextMenu } from './json-forms-tree-container';
 import { JsonFormsTreeLabelProvider } from './json-forms-tree-label-provider';
-import { JsonFormsTreeContextMenu, JsonFormsTreeAnchor } from './json-forms-tree-container';
 
 @injectable()
 export class JsonFormsTreeWidget extends TreeWidget {

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
@@ -1,10 +1,26 @@
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 import {
   CompositeTreeNode,
   ExpandableTreeNode,
   SelectableTreeNode,
   TreeDecoration,
   TreeNode
-} from "@theia/core/lib/browser/tree";
+} from '@theia/core/lib/browser/tree';
 
 export namespace JsonFormsTree {
   export interface RootNode extends CompositeTreeNode { }
@@ -32,7 +48,7 @@ export namespace JsonFormsTree {
 
   export namespace Node {
     export function is(node: TreeNode | undefined): node is Node {
-      if (!!node && "jsonforms" in node) {
+      if (!!node && 'jsonforms' in node) {
         const { jsonforms } = node;
         return !!jsonforms;
       }

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
@@ -13,13 +13,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-
 import {
   CompositeTreeNode,
   ExpandableTreeNode,
   SelectableTreeNode,
   TreeDecoration,
-  TreeNode
+  TreeNode,
 } from '@theia/core/lib/browser/tree';
 
 export namespace JsonFormsTree {

--- a/web/coffee-editor-extension/src/browser/models/coffee-schemas.ts
+++ b/web/coffee-editor-extension/src/browser/models/coffee-schemas.ts
@@ -163,12 +163,12 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/component'},
-              { '$ref': '#/definitions/machine'},
-              { '$ref': '#/definitions/controlunit'},
-              { '$ref': '#/definitions/brewingunit'},
-              { '$ref': '#/definitions/diptray'},
-              { '$ref': '#/definitions/watertank'}
+              { '$ref': '#/definitions/component' },
+              { '$ref': '#/definitions/machine' },
+              { '$ref': '#/definitions/controlunit' },
+              { '$ref': '#/definitions/brewingunit' },
+              { '$ref': '#/definitions/diptray' },
+              { '$ref': '#/definitions/watertank' }
             ]
           }
         },
@@ -195,12 +195,12 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/component'},
-              { '$ref': '#/definitions/machine'},
-              { '$ref': '#/definitions/controlunit'},
-              { '$ref': '#/definitions/brewingunit'},
-              { '$ref': '#/definitions/diptray'},
-              { '$ref': '#/definitions/watertank'}
+              { '$ref': '#/definitions/component' },
+              { '$ref': '#/definitions/machine' },
+              { '$ref': '#/definitions/controlunit' },
+              { '$ref': '#/definitions/brewingunit' },
+              { '$ref': '#/definitions/diptray' },
+              { '$ref': '#/definitions/watertank' }
             ]
           }
         },
@@ -225,12 +225,12 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/component'},
-              { '$ref': '#/definitions/machine'},
-              { '$ref': '#/definitions/controlunit'},
-              { '$ref': '#/definitions/brewingunit'},
-              { '$ref': '#/definitions/diptray'},
-              { '$ref': '#/definitions/watertank'}
+              { '$ref': '#/definitions/component' },
+              { '$ref': '#/definitions/machine' },
+              { '$ref': '#/definitions/controlunit' },
+              { '$ref': '#/definitions/brewingunit' },
+              { '$ref': '#/definitions/diptray' },
+              { '$ref': '#/definitions/watertank' }
             ]
           }
         },
@@ -271,12 +271,12 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/component'},
-              { '$ref': '#/definitions/machine'},
-              { '$ref': '#/definitions/controlunit'},
-              { '$ref': '#/definitions/brewingunit'},
-              { '$ref': '#/definitions/diptray'},
-              { '$ref': '#/definitions/watertank'}
+              { '$ref': '#/definitions/component' },
+              { '$ref': '#/definitions/machine' },
+              { '$ref': '#/definitions/controlunit' },
+              { '$ref': '#/definitions/brewingunit' },
+              { '$ref': '#/definitions/diptray' },
+              { '$ref': '#/definitions/watertank' }
             ]
           }
         }
@@ -294,12 +294,12 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/component'},
-              { '$ref': '#/definitions/machine'},
-              { '$ref': '#/definitions/controlunit'},
-              { '$ref': '#/definitions/brewingunit'},
-              { '$ref': '#/definitions/diptray'},
-              { '$ref': '#/definitions/watertank'}
+              { '$ref': '#/definitions/component' },
+              { '$ref': '#/definitions/machine' },
+              { '$ref': '#/definitions/controlunit' },
+              { '$ref': '#/definitions/brewingunit' },
+              { '$ref': '#/definitions/diptray' },
+              { '$ref': '#/definitions/watertank' }
             ]
           }
         }
@@ -317,12 +317,12 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/component'},
-              { '$ref': '#/definitions/machine'},
-              { '$ref': '#/definitions/controlunit'},
-              { '$ref': '#/definitions/brewingunit'},
-              { '$ref': '#/definitions/diptray'},
-              { '$ref': '#/definitions/watertank'}
+              { '$ref': '#/definitions/component' },
+              { '$ref': '#/definitions/machine' },
+              { '$ref': '#/definitions/controlunit' },
+              { '$ref': '#/definitions/brewingunit' },
+              { '$ref': '#/definitions/diptray' },
+              { '$ref': '#/definitions/watertank' }
             ]
           }
         }
@@ -438,12 +438,12 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/automatictask'},
-              { '$ref': '#/definitions/manualtask'},
-              { '$ref': '#/definitions/fork'},
-              { '$ref': '#/definitions/join'},
-              { '$ref': '#/definitions/decision'},
-              { '$ref': '#/definitions/merge'}
+              { '$ref': '#/definitions/automatictask' },
+              { '$ref': '#/definitions/manualtask' },
+              { '$ref': '#/definitions/fork' },
+              { '$ref': '#/definitions/join' },
+              { '$ref': '#/definitions/decision' },
+              { '$ref': '#/definitions/merge' }
             ]
           }
         },
@@ -451,8 +451,8 @@ export const coffeeSchema = {
           'type': 'array',
           'items': {
             'anyOf': [
-              { '$ref': '#/definitions/flow'},
-              { '$ref': '#/definitions/weightedflow'},
+              { '$ref': '#/definitions/flow' },
+              { '$ref': '#/definitions/weightedflow' },
             ]
           }
         }
@@ -601,31 +601,31 @@ export const coffeeSchema = {
 };
 
 export const instance = {
-  'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine',
-  'children' : [ {
-    'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit'
+  'eClass': 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine',
+  'children': [{
+    'eClass': 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit'
   }, {
-    'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit',
-    'processor' : {
-      'clockSpeed' : 5,
-      'numberOfCores' : 10,
-      'socketconnectorType' : 'Z51',
-      'thermalDesignPower' : 100
+    'eClass': 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit',
+    'processor': {
+      'clockSpeed': 5,
+      'numberOfCores': 10,
+      'socketconnectorType': 'Z51',
+      'thermalDesignPower': 100
     },
-    'display' : {
-      'width' : 10,
-      'height' : 20
+    'display': {
+      'width': 10,
+      'height': 20
     }
-  } ],
-  'name' : 'Super Brewer 3000',
-  'workflows' : [ {
-    'nodes' : [ {
-      'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask',
-      'name' : 'PreHeat',
-      'component' : {
-        'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit',
-        '$ref' : '//@children.0'
+  }],
+  'name': 'Super Brewer 3000',
+  'workflows': [{
+    'nodes': [{
+      'eClass': 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask',
+      'name': 'PreHeat',
+      'component': {
+        'eClass': 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit',
+        '$ref': '//@children.0'
       }
-    } ]
-  } ]
+    }]
+  }]
 };

--- a/web/coffee-editor-extension/src/browser/models/coffee-schemas.ts
+++ b/web/coffee-editor-extension/src/browser/models/coffee-schemas.ts
@@ -1,3 +1,19 @@
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 export const controlUnitView = {
   'type': 'VerticalLayout',
   'elements': [
@@ -132,7 +148,7 @@ export const machineView = {
 export const brewingView = {
   'type': 'Label',
   'text': 'Brewing Unit'
-}
+};
 
 export const coffeeSchema = {
   'definitions': {
@@ -484,10 +500,10 @@ export const coffeeSchema = {
         },
         'duration': {
           'type': 'integer',
-        },       
+        },
         // missing component link
       },
-      //'additionalProperties': false
+      // 'additionalProperties': false
     },
     'manualtask': {
       '$id': '#manualtask',
@@ -563,7 +579,7 @@ export const coffeeSchema = {
         }
         // Missing Source and Target
       },
-      //'additionalProperties': false
+      // 'additionalProperties': false
     },
     'weightedflow': {
       '$id': '#weightedflow',
@@ -578,37 +594,37 @@ export const coffeeSchema = {
         }
         // Missing Source and Target
       },
-      //'additionalProperties': false
+      // 'additionalProperties': false
     },
   },
   '$ref': '#/definitions/machine'
 };
 
 export const instance = {
-  "eClass" : "http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine",
-  "children" : [ {
-    "eClass" : "http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit"
+  'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//Machine',
+  'children' : [ {
+    'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit'
   }, {
-    "eClass" : "http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit",
-    "processor" : {
-      "clockSpeed" : 5,
-      "numberOfCores" : 10,
-      "socketconnectorType" : "Z51",
-      "thermalDesignPower" : 100
+    'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//ControlUnit',
+    'processor' : {
+      'clockSpeed' : 5,
+      'numberOfCores' : 10,
+      'socketconnectorType' : 'Z51',
+      'thermalDesignPower' : 100
     },
-    "display" : {
-      "width" : 10,
-      "height" : 20
+    'display' : {
+      'width' : 10,
+      'height' : 20
     }
   } ],
-  "name" : "Super Brewer 3000",
-  "workflows" : [ {
-    "nodes" : [ {
-      "eClass" : "http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask",
-      "name" : "PreHeat",
-      "component" : {
-        "eClass" : "http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit",
-        "$ref" : "//@children.0"
+  'name' : 'Super Brewer 3000',
+  'workflows' : [ {
+    'nodes' : [ {
+      'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//AutomaticTask',
+      'name' : 'PreHeat',
+      'component' : {
+        'eClass' : 'http://www.eclipsesource.com/modelserver/example/coffeemodel#//BrewingUnit',
+        '$ref' : '//@children.0'
       }
     } ]
   } ]

--- a/web/coffee-editor-extension/src/browser/style/index.css
+++ b/web/coffee-editor-extension/src/browser/style/index.css
@@ -1,20 +1,20 @@
-svg {border:none;}
-button[type='button'] {padding:0}
+svg {
+  border: none;
+}
 
-.json-forms-tree-editor,
-.json-forms-tree-editor-sash,
-.json-forms-tree-editor-tree,
-.json-forms-tree-editor-forms {
+button[type='button'] {
+  padding: 0
+}
+
+.json-forms-tree-editor, .json-forms-tree-editor-sash, .json-forms-tree-editor-tree, .json-forms-tree-editor-forms {
   height: 100%;
 }
 
-.json-forms-tree-editor,
-.json-forms-tree-editor-sash {
+.json-forms-tree-editor, .json-forms-tree-editor-sash {
   width: 100%;
 }
 
-.json-forms-tree-editor-tree,
-.json-forms-tree-editor-forms {
+.json-forms-tree-editor-tree, .json-forms-tree-editor-forms {
   overflow-y: auto;
 }
 

--- a/web/tslint.json
+++ b/web/tslint.json
@@ -5,5 +5,8 @@
     "extends": [
         "./configs/errors.tslint.json",
         "./configs/warnings.tslint.json"
-    ]
+    ],
+    "rules": {
+        "no-any": false
+    }
 }


### PR DESCRIPTION
Fixes point two of #117:
* Apply TSLint auto fixes to coffee-editor-expansion package
* Fix various non-autofix lint issues in the coffee editor extension
* Disable no-any rule as it sometimes makes sense to use the any type
* Apply code formatting to coffee editor extension