### PR TITLE
Refactor tree node creation and label provider to be independent of coffee model

### DIFF
--- a/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
@@ -21,12 +21,14 @@ import URI from '@theia/core/lib/common/uri';
 import { ContainerModule } from 'inversify';
 
 import { CoffeeTreeEditorContribution } from './coffee-editor-tree-contribution';
+import { CoffeeTreeNodeFactory } from './coffee/coffee-node-factory';
 import { CoffeeLabelProviderContribution } from './CoffeeLabelProvider';
 import {
   JsonFormsTreeEditorWidget,
   JsonFormsTreeEditorWidgetOptions,
 } from './json-forms-tree-editor/json-forms-tree-editor-widget';
 import { JSONFormsWidget } from './json-forms-tree-editor/json-forms-widget';
+import { JsonFormsTree } from './json-forms-tree/json-forms-tree';
 import { createJsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-container';
 import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 import { JsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-widget';
@@ -42,6 +44,7 @@ export default new ContainerModule(bind => {
   bind(CommandContribution).to(CoffeeTreeEditorContribution);
   bind(JsonFormsTreeEditorWidget).toSelf();
   bind(JsonFormsTreeLabelProvider).toSelf();
+  bind(JsonFormsTree.NodeFactory).to(CoffeeTreeNodeFactory);
 
   bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({
     id: JsonFormsTreeEditorWidget.WIDGET_ID,

--- a/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-frontend-module.ts
@@ -22,6 +22,7 @@ import { ContainerModule } from 'inversify';
 
 import { CoffeeTreeEditorContribution } from './coffee-editor-tree-contribution';
 import { CoffeeTreeNodeFactory } from './coffee/coffee-node-factory';
+import { CoffeeTreeLabelProvider } from './coffee/coffee-tree-label-provider';
 import { CoffeeLabelProviderContribution } from './CoffeeLabelProvider';
 import {
   JsonFormsTreeEditorWidget,
@@ -30,7 +31,6 @@ import {
 import { JSONFormsWidget } from './json-forms-tree-editor/json-forms-widget';
 import { JsonFormsTree } from './json-forms-tree/json-forms-tree';
 import { createJsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-container';
-import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 import { JsonFormsTreeWidget } from './json-forms-tree/json-forms-tree-widget';
 
 export default new ContainerModule(bind => {
@@ -43,7 +43,7 @@ export default new ContainerModule(bind => {
   bind(MenuContribution).to(CoffeeTreeEditorContribution);
   bind(CommandContribution).to(CoffeeTreeEditorContribution);
   bind(JsonFormsTreeEditorWidget).toSelf();
-  bind(JsonFormsTreeLabelProvider).toSelf();
+  bind(JsonFormsTree.LabelProvider).to(CoffeeTreeLabelProvider);
   bind(JsonFormsTree.NodeFactory).to(CoffeeTreeNodeFactory);
 
   bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({

--- a/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
@@ -19,19 +19,19 @@ import URI from '@theia/core/lib/common/uri';
 import { inject, injectable } from 'inversify';
 
 import { JsonFormsTreeEditorWidget } from './json-forms-tree-editor/json-forms-tree-editor-widget';
+import { JsonFormsTree } from './json-forms-tree/json-forms-tree';
 import {
   AddCommandHandler,
   JsonFormsTreeCommands,
   JsonFormsTreeContextMenu,
   OpenWorkflowDiagramCommandHandler,
 } from './json-forms-tree/json-forms-tree-container';
-import { JsonFormsTreeLabelProvider } from './json-forms-tree/json-forms-tree-label-provider';
 
 @injectable()
 export class CoffeeTreeEditorContribution extends NavigatableWidgetOpenHandler<JsonFormsTreeEditorWidget> implements CommandContribution, MenuContribution {
   @inject(ApplicationShell) protected shell: ApplicationShell;
   @inject(OpenerService) protected opener: OpenerService;
-  @inject(JsonFormsTreeLabelProvider) protected labelProvider: JsonFormsTreeLabelProvider;
+  @inject(JsonFormsTree.LabelProvider) protected labelProvider: JsonFormsTree.LabelProvider;
 
   readonly id = JsonFormsTreeEditorWidget.WIDGET_ID;
   readonly label = JsonFormsTreeEditorWidget.WIDGET_LABEL;

--- a/web/coffee-editor-extension/src/browser/coffee/coffee-node-factory.ts
+++ b/web/coffee-editor-extension/src/browser/coffee/coffee-node-factory.ts
@@ -1,0 +1,125 @@
+/*!
+ * Copyright (C) 2019 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+import { ILogger } from '@theia/core';
+import { inject, injectable } from 'inversify';
+import { v4 } from 'uuid';
+
+import { CoffeeModel } from '../json-forms-tree/coffee-model';
+import { JsonFormsTree } from '../json-forms-tree/json-forms-tree';
+import { JsonFormsTreeLabelProvider } from '../json-forms-tree/json-forms-tree-label-provider';
+
+@injectable()
+export class CoffeeTreeNodeFactory implements JsonFormsTree.NodeFactory {
+
+    constructor(
+        @inject(JsonFormsTreeLabelProvider) private readonly labelProvider: JsonFormsTreeLabelProvider,
+        @inject(ILogger) private readonly logger: ILogger) {
+    }
+
+    mapDataToNodes(treeData: JsonFormsTree.TreeData): JsonFormsTree.Node[] {
+        const node = this.mapData(treeData.data);
+        if (node) {
+            return [node];
+        }
+        return [];
+    }
+
+    mapData(currentData: any, parent?: JsonFormsTree.Node, property?: string, type?: string, index?: number): JsonFormsTree.Node {
+        if (!currentData) {
+            // sanity check
+            this.logger.warn('mapData called without data');
+            return undefined;
+        }
+        const node = {
+            ...this.defaultNode(),
+            name: this.labelProvider.getName(currentData),
+            parent: parent,
+            jsonforms: {
+                type: this.getType(type, currentData),
+                data: currentData,
+                property: property,
+                index: index ? index.toFixed(0) : undefined
+            }
+        };
+        // containments
+        if (parent) {
+            parent.children.push(node);
+            parent.expanded = true;
+        }
+        if (currentData.children) {
+            // component types
+            currentData.children.forEach((element, idx) => {
+                this.mapData(element, node, 'children', undefined, idx);
+            });
+        }
+        if (currentData.workflows) {
+            // machine type
+            currentData.workflows.forEach((element, idx) => {
+                this.mapData(element, node, 'workflows', CoffeeModel.Type.Workflow, idx);
+            });
+        }
+        if (currentData.nodes) {
+            // workflow type
+            currentData.nodes.forEach((element, idx) => {
+                this.mapData(element, node, 'nodes', undefined, idx);
+            });
+        }
+        if (currentData.flows) {
+            // workflow type
+            currentData.flows.forEach((element, idx) => {
+                this.mapData(element, node, 'flows', undefined, idx);
+            });
+        }
+        return node;
+    }
+
+    hasCreatableChildren(node: JsonFormsTree.Node): boolean {
+        return node ? CoffeeModel.childrenMapping.get(node.jsonforms.type) !== undefined : false;
+    }
+
+    protected defaultNode(): Pick<
+        JsonFormsTree.Node,
+        'id' | 'expanded' | 'selected' | 'parent' | 'decorationData' | 'children'
+    > {
+        return {
+            id: v4(),
+            expanded: false,
+            selected: false,
+            parent: undefined,
+            decorationData: {},
+            children: []
+        };
+    }
+
+    protected getType(type: string, data: any): string {
+        // TODO: eClass should always be sent from server
+
+        if (type) {
+            // given eClass
+            return type;
+        }
+        if (data.eClass) {
+            // eClass of node
+            return data.eClass;
+        }
+        // guess
+        if (data.nodes) {
+            return CoffeeModel.Type.Workflow;
+        }
+        return undefined;
+    }
+
+}

--- a/web/coffee-editor-extension/src/browser/coffee/coffee-node-factory.ts
+++ b/web/coffee-editor-extension/src/browser/coffee/coffee-node-factory.ts
@@ -19,13 +19,12 @@ import { v4 } from 'uuid';
 
 import { CoffeeModel } from '../json-forms-tree/coffee-model';
 import { JsonFormsTree } from '../json-forms-tree/json-forms-tree';
-import { JsonFormsTreeLabelProvider } from '../json-forms-tree/json-forms-tree-label-provider';
 
 @injectable()
 export class CoffeeTreeNodeFactory implements JsonFormsTree.NodeFactory {
 
     constructor(
-        @inject(JsonFormsTreeLabelProvider) private readonly labelProvider: JsonFormsTreeLabelProvider,
+        @inject(JsonFormsTree.LabelProvider) private readonly labelProvider: JsonFormsTree.LabelProvider,
         @inject(ILogger) private readonly logger: ILogger) {
     }
 

--- a/web/coffee-editor-extension/src/browser/coffee/coffee-tree-label-provider.ts
+++ b/web/coffee-editor-extension/src/browser/coffee/coffee-tree-label-provider.ts
@@ -17,8 +17,8 @@ import { TreeNode } from '@theia/core/lib/browser/tree/tree';
 import URI from '@theia/core/lib/common/uri';
 import { injectable } from 'inversify';
 
-import { CoffeeModel } from './coffee-model';
-import { JsonFormsTree } from './json-forms-tree';
+import { CoffeeModel } from '../json-forms-tree/coffee-model';
+import { JsonFormsTree } from '../json-forms-tree/json-forms-tree';
 
 const DEFAULT_COLOR = 'black';
 
@@ -49,7 +49,7 @@ const ICON_CLASSES: Map<string, string> = new Map([
 const UNKNOWN_ICON = 'fa-question-circle ' + DEFAULT_COLOR;
 
 @injectable()
-export class JsonFormsTreeLabelProvider {
+export class CoffeeTreeLabelProvider implements JsonFormsTree.LabelProvider {
 
   public getIconClass(node: TreeNode | string): string {
     let iconClass: string;

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree-widget.tsx
@@ -24,7 +24,6 @@ import { v4 } from 'uuid';
 
 import { JsonFormsTree } from './json-forms-tree';
 import { JsonFormsTreeAnchor, JsonFormsTreeContextMenu } from './json-forms-tree-container';
-import { JsonFormsTreeLabelProvider } from './json-forms-tree-label-provider';
 
 @injectable()
 export class JsonFormsTreeWidget extends TreeWidget {
@@ -37,7 +36,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
     @inject(TreeProps) readonly props: TreeProps,
     @inject(TreeModel) readonly model: TreeModel,
     @inject(ContextMenuRenderer) readonly contextMenuRenderer: ContextMenuRenderer,
-    @inject(JsonFormsTreeLabelProvider) readonly labelProvider: JsonFormsTreeLabelProvider,
+    @inject(JsonFormsTree.LabelProvider) readonly labelProvider: JsonFormsTree.LabelProvider,
     @inject(JsonFormsTree.NodeFactory) protected readonly nodeFactory: JsonFormsTree.NodeFactory
   ) {
     super(props, model, contextMenuRenderer);

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
@@ -45,6 +45,49 @@ export namespace JsonFormsTree {
     };
   }
 
+  export interface TreeData {
+    error: boolean;
+    data?: any;
+  }
+
+  /**
+   * Encapsulates logic to create the tree nodes from the tree's input data.
+   */
+  export const NodeFactory = Symbol('NodeFactory');
+  export interface NodeFactory {
+
+    /**
+     * Recursively creates the tree's nodes from the given data.
+     *
+     * @param treeData The tree's data
+     * @returns The tree's shown root nodes (not to confuse with the invisible RootNode)
+     */
+    mapDataToNodes(treeData: TreeData): Node[];
+
+    /**
+     * Creates the corresponding TreeNode for the given data.
+     *
+     * @param currentData The current instance data to map to a tree node
+     * @param parent This node's parent node
+     * @param property The JSON property which this node's data is contained in
+     * @param type The type of the node
+     * @param index The index which this node's data is contained in the parent property
+     */
+    mapData(
+      currentData: any,
+      parent?: Node,
+      property?: string,
+      eClass?: string,
+      index?: number
+    ): Node;
+
+    /**
+     * @param node The node to create a child for
+     * @returns true if child nodes can be created
+     */
+    hasCreatableChildren(node: Node): boolean;
+  }
+
   export namespace Node {
     export function is(node: TreeNode | undefined): node is Node {
       if (!!node && 'jsonforms' in node) {

--- a/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
+++ b/web/coffee-editor-extension/src/browser/json-forms-tree/json-forms-tree.ts
@@ -88,6 +88,23 @@ export namespace JsonFormsTree {
     hasCreatableChildren(node: Node): boolean;
   }
 
+  /**
+   * Label provider for the tree providing icons and display names for tree nodes.
+   */
+  export const LabelProvider = Symbol('LabelProvider');
+  export interface LabelProvider {
+    /**
+     * @param node The tree node or the node's type to get the icon css for
+     * @return the css class(es) specifying the tree node's icon
+     */
+    getIconClass(node: TreeNode | string): string;
+
+    /**
+     * @param data The display name for the given data
+     */
+    getName(data: any): string;
+  }
+
   export namespace Node {
     export function is(node: TreeNode | undefined): node is Node {
       if (!!node && 'jsonforms' in node) {


### PR DESCRIPTION
Part of point 3 of #117 

### Refactor node creation to new NodeFactory interface
Make the json forms tree widget independent of the coffee model by exracting the tree node generation:
* Create a new interface `NodeFactory` in the JsonFormsTree namespace
* Implement coffee node factory

### Generalize tree label provider
* Define tree label provider interface
* Inject interface in tree widget
* Implement interface in coffee label provider
* Rename and move coffee label provide