### PR TITLE
Move example diagram to initial Viewport center

### DIFF
--- a/backend/examples/SuperBrewer3000/superbrewer3000.coffeenotation
+++ b/backend/examples/SuperBrewer3000/superbrewer3000.coffeenotation
@@ -1,107 +1,105 @@
 <?xml version="1.0" encoding="ASCII"?>
-<xmi:XMI xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfnotation="http://www.eclipsesource.com/glsp/examples/workflow/notation">
-  <wfnotation:Diagram>
-    <semanticElement uri="//@workflows.0"/>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.0"/>
-      <position x="-27.0" y="305.0"/>
-      <size width="127.71875" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.1"/>
-      <position x="-11.0" y="405.0"/>
-      <size width="103.359375" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.7"/>
-      <position x="-118.0" y="22.0"/>
-      <size width="141.953125" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.8"/>
-      <position x="5.0" y="-54.0"/>
-      <size width="30.953125" height="37.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.2"/>
-      <position x="39.109375" y="21.5"/>
-      <size width="161.9375" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.3"/>
-      <position x="161.109375" y="406.5"/>
-      <size width="105.015625" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.4"/>
-      <position x="-209.890625" y="-160.5"/>
-      <size width="101.90625" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.5"/>
-      <position x="-65.0" y="206.0"/>
-      <size width="200.5" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.7"/>
-      <position x="285.109375" y="35.75"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.8"/>
-      <position x="46.109375" y="208.75"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.6"/>
-      <position x="-58.0" y="-159.0"/>
-      <size width="176.640625" height="52.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.3"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.8"/>
-      <position x="51.109375" y="-125.25"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.4"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.5"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.6"/>
-    </elements>
-    <elements xsi:type="wfnotation:Shape">
-      <semanticElement uri="//@workflows.0/@nodes.9"/>
-      <position x="18.359375" y="120.75"/>
-      <size width="27.0" height="37.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.7"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.8"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.9"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.2"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.1"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.0"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.7"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.8"/>
-    </elements>
-    <elements xsi:type="wfnotation:Edge">
-      <semanticElement uri="//@workflows.0/@flows.9"/>
-    </elements>
-  </wfnotation:Diagram>
-</xmi:XMI>
+<wfnotation:Diagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:wfnotation="http://www.eclipsesource.com/glsp/examples/workflow/notation">
+  <semanticElement uri="//@workflows.0"/>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.0"/>
+    <position x="787.0" y="815.0"/>
+    <size width="127.5" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.1"/>
+    <position x="803.0" y="915.0"/>
+    <size width="103.03125" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.7"/>
+    <position x="696.0" y="532.0"/>
+    <size width="142.296875" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.8"/>
+    <position x="819.0" y="456.0"/>
+    <size width="30.953125" height="37.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.2"/>
+    <position x="853.109375" y="531.5"/>
+    <size width="161.9375" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.3"/>
+    <position x="975.109375" y="916.5"/>
+    <size width="105.234375" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.4"/>
+    <position x="604.109375" y="349.5"/>
+    <size width="101.921875" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.5"/>
+    <position x="749.0" y="716.0"/>
+    <size width="200.828125" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.7"/>
+    <position x="285.109375" y="35.75"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.8"/>
+    <position x="46.109375" y="208.75"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.6"/>
+    <position x="756.0" y="351.0"/>
+    <size width="176.765625" height="52.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.3"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.8"/>
+    <position x="51.109375" y="-125.25"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.4"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.5"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.6"/>
+  </elements>
+  <elements xsi:type="wfnotation:Shape">
+    <semanticElement uri="//@workflows.0/@nodes.9"/>
+    <position x="832.359375" y="630.75"/>
+    <size width="27.0" height="37.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.7"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.8"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.9"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.2"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.1"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.0"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.7"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.8"/>
+  </elements>
+  <elements xsi:type="wfnotation:Edge">
+    <semanticElement uri="//@workflows.0/@flows.9"/>
+  </elements>
+</wfnotation:Diagram>


### PR DESCRIPTION
Move the diagram to the center of the initial viewport. This way the diagram is always centered after initial loading. Quick-fix for #186. However this works only for diagrams that are not larger than the initial canvas size, because the zoom-level is always reset to 100% on init.

To achieve the exact behavior described in #186 (center & zoom) an actual Fit-To-Screen action has to be sent after the diagram loading which could be a bit tricky. 