### PR TITLE
Add maven and libxml2-utils as dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ Install yarn.
 
     npm install -g yarn
 
+Install maven
+    
+    sudo apt-get install maven
+
 Install linux packages (if necessary).
 
-    sudo apt-get install g++-4.8 libsecret-1-dev xvfb libx11-dev libxkbfile-dev
+    sudo apt-get install g++-4.8 libsecret-1-dev xvfb libx11-dev libxkbfile-dev libxml2-utils
 
 ## Getting started
 


### PR DESCRIPTION
When you executed the command ./run.sh -b -c -d -f it can give errors, but just tries to continue.
In my case I did not install mvn and libxml2-utils yet.
In the download script xmllint is used to figure out the right version to download.