### PR TITLE
Remove model server dependencies from JsonForms Tree component

### DIFF
--- a/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-editor-tree-contribution.ts
@@ -25,6 +25,7 @@ import { JsonFormsTreeContextMenu } from 'jsonforms-tree-extension/lib/browser/t
 
 import { CoffeeTreeCommands, OpenWorkflowDiagramCommandHandler } from './coffee-tree/coffee-tree-container';
 import { CoffeeTreeEditorWidget } from './coffee-tree/coffee-tree-editor-widget';
+import { CoffeeTreeLabelProvider } from './coffee-tree/coffee-tree-label-provider';
 
 @injectable()
 export class CoffeeTreeEditorContribution extends JsonFormsTreeEditorContribution {
@@ -32,7 +33,7 @@ export class CoffeeTreeEditorContribution extends JsonFormsTreeEditorContributio
   @inject(OpenerService) protected opener: OpenerService;
 
   constructor(
-    @inject(JsonFormsTree.LabelProvider) labelProvider: JsonFormsTree.LabelProvider,
+    @inject(CoffeeTreeLabelProvider) labelProvider: JsonFormsTree.LabelProvider,
     @inject(ModelService) modelService: ModelService
   ) {
     super(modelService, labelProvider);

--- a/web/coffee-editor-extension/src/browser/coffee-tree/coffee-node-factory.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-tree/coffee-node-factory.ts
@@ -36,7 +36,7 @@ export class CoffeeTreeNodeFactory implements JsonFormsTree.NodeFactory {
         return [];
     }
 
-    mapData(data: any, parent?: JsonFormsTree.Node, property?: string, index?: number): JsonFormsTree.Node {
+    mapData(data: any, parent?: JsonFormsTree.Node, property?: string, indexOrKey?: number | string): JsonFormsTree.Node {
         if (!data) {
             // sanity check
             this.logger.warn('mapData called without data');
@@ -50,7 +50,7 @@ export class CoffeeTreeNodeFactory implements JsonFormsTree.NodeFactory {
                 type: this.getType(data.eClass, data),
                 data: data,
                 property: property,
-                index: index !== undefined ? index.toFixed(0) : undefined
+                index: typeof indexOrKey === 'number' ? indexOrKey.toFixed(0) : indexOrKey
             }
         };
         // containments

--- a/web/coffee-editor-extension/src/browser/coffee-tree/coffee-node-factory.ts
+++ b/web/coffee-editor-extension/src/browser/coffee-tree/coffee-node-factory.ts
@@ -36,19 +36,19 @@ export class CoffeeTreeNodeFactory implements JsonFormsTree.NodeFactory {
         return [];
     }
 
-    mapData(currentData: any, parent?: JsonFormsTree.Node, property?: string, type?: string, index?: number): JsonFormsTree.Node {
-        if (!currentData) {
+    mapData(data: any, parent?: JsonFormsTree.Node, property?: string, index?: number): JsonFormsTree.Node {
+        if (!data) {
             // sanity check
             this.logger.warn('mapData called without data');
             return undefined;
         }
         const node = {
             ...this.defaultNode(),
-            name: this.labelProvider.getName(currentData),
+            name: this.labelProvider.getName(data),
             parent: parent,
             jsonforms: {
-                type: this.getType(type, currentData),
-                data: currentData,
+                type: this.getType(data.eClass, data),
+                data: data,
                 property: property,
                 index: index !== undefined ? index.toFixed(0) : undefined
             }
@@ -58,28 +58,29 @@ export class CoffeeTreeNodeFactory implements JsonFormsTree.NodeFactory {
             parent.children.push(node);
             parent.expanded = true;
         }
-        if (currentData.children) {
+        if (data.children) {
             // component types
-            currentData.children.forEach((element, idx) => {
-                this.mapData(element, node, 'children', undefined, idx);
+            data.children.forEach((element, idx) => {
+                this.mapData(element, node, 'children', idx);
             });
         }
-        if (currentData.workflows) {
+        if (data.workflows) {
             // machine type
-            currentData.workflows.forEach((element, idx) => {
-                this.mapData(element, node, 'workflows', CoffeeModel.Type.Workflow, idx);
+            data.workflows.forEach((element, idx) => {
+                element.eClass = CoffeeModel.Type.Workflow;
+                this.mapData(element, node, 'workflows', idx);
             });
         }
-        if (currentData.nodes) {
+        if (data.nodes) {
             // workflow type
-            currentData.nodes.forEach((element, idx) => {
-                this.mapData(element, node, 'nodes', undefined, idx);
+            data.nodes.forEach((element, idx) => {
+                this.mapData(element, node, 'nodes', idx);
             });
         }
-        if (currentData.flows) {
+        if (data.flows) {
             // workflow type
-            currentData.flows.forEach((element, idx) => {
-                this.mapData(element, node, 'flows', undefined, idx);
+            data.flows.forEach((element, idx) => {
+                this.mapData(element, node, 'flows', idx);
             });
         }
         return node;

--- a/web/coffee-editor-extension/src/browser/coffee-tree/coffee-tree-editor-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/coffee-tree/coffee-tree-editor-widget.tsx
@@ -196,11 +196,11 @@ export class CoffeeTreeEditorWidget extends JsonFormsTreeEditorWidget {
     );
     this.modelServerApi.edit(this.getModelIDToRequest(), removeCommand);
   }
-  protected addNode({ node, eClass, property }: AddCommandProperty): void {
+  protected addNode({ node, type, property }: AddCommandProperty): void {
     const addCommand = ModelServerCommandUtil.createAddCommand(
       this.getNodeDescription(node),
       property,
-      [{ eClass }]
+      [{ eClass: type }]
     );
     this.modelServerApi.edit(this.getModelIDToRequest(), addCommand);
   }

--- a/web/coffee-editor-extension/src/browser/coffee-tree/coffee-tree-editor-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/coffee-tree/coffee-tree-editor-widget.tsx
@@ -20,6 +20,7 @@ import {
   ModelServerCommandUtil,
   ModelServerReferenceDescription,
 } from '@modelserver/theia/lib/common';
+import { TreeNode } from '@theia/core/lib/browser';
 import { ILogger } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
@@ -149,11 +150,11 @@ export class CoffeeTreeEditorWidget extends JsonFormsTreeEditorWidget {
       this.treeWidget.setData({ error: response.statusMessage });
       this.renderError(
         "An error occurred when requesting '" +
-          this.getModelIDToRequest() +
-          "' - Status " +
-          response.statusCode +
-          ' ' +
-          response.statusMessage
+        this.getModelIDToRequest() +
+        "' - Status " +
+        response.statusCode +
+        ' ' +
+        response.statusMessage
       );
       this.instanceData = undefined;
       return;
@@ -209,17 +210,18 @@ export class CoffeeTreeEditorWidget extends JsonFormsTreeEditorWidget {
     super.dispose();
   }
 
-  protected handleFormUpdate(data: any, node: ModelServerReferenceDescription) {
+  protected handleFormUpdate(data: any, node: JsonFormsTree.Node) {
+    const modelServerNode = this.getNodeDescription(node);
     Object.keys(data)
       .filter(key => key !== 'eClass')
       .forEach(key => {
         if (
           data[key] instanceof Object &&
-          !isEqual(this.selectedNode.jsonforms.data[key], data[key])
+          !isEqual(node.jsonforms.data[key], data[key])
         ) {
           const eClass = data[key].eClass || this.getEClassFromKey(key);
           const setCommand = ModelServerCommandUtil.createSetCommand(
-            node,
+            modelServerNode,
             key,
             []
           );
@@ -231,13 +233,40 @@ export class CoffeeTreeEditorWidget extends JsonFormsTreeEditorWidget {
           this.modelServerApi.edit(this.getModelIDToRequest(), setCommand);
         } else {
           const setCommand = ModelServerCommandUtil.createSetCommand(
-            node,
+            modelServerNode,
             key,
             [data[key]]
           );
           this.modelServerApi.edit(this.getModelIDToRequest(), setCommand);
         }
       });
+  }
+
+  /**
+   * Create the corresponding ModelServerReferenceDescription for the given tree node.
+   * @param node The tree node to convert
+   */
+  protected getNodeDescription(node: JsonFormsTree.Node): ModelServerReferenceDescription {
+    const getRefSegment = (n: JsonFormsTree.Node) =>
+      n.jsonforms.property
+        ? `@${n.jsonforms.property}` +
+        (n.jsonforms.index ? `.${n.jsonforms.index}` : '')
+        : '';
+    let refToNode = '';
+    let toCheck: TreeNode = node;
+    while (toCheck && JsonFormsTree.Node.is(toCheck)) {
+      const parentRefSeg = getRefSegment(toCheck);
+      refToNode =
+        parentRefSeg === '' ? refToNode : '/' + parentRefSeg + refToNode;
+      toCheck = toCheck.parent;
+    }
+    const ownerRef = `${
+      this.workspaceService.workspace.uri
+      }/${this.getModelIDToRequest()}#/${refToNode}`;
+    return {
+      eClass: node.jsonforms.type,
+      $ref: ownerRef.replace('file:///', 'file:/')
+    };
   }
 }
 export namespace CoffeeTreeEditorWidget {

--- a/web/jsonforms-tree/DOCUMENTATION.MD
+++ b/web/jsonforms-tree/DOCUMENTATION.MD
@@ -1,0 +1,81 @@
+This is the usage documentation for the json forms tree editor.
+
+# Configuring a tree editor
+To use the tree editor for a custom model, the following classes and interfaces need to be extended resp. implemented.
+
+## JsonFormsTreeEditorWidget
+The implementation of this abstract class is the the whole editor widget containing a tree and a detail
+whose content depends on the node selected in the tree.
+
+You need to implement `addNode` and `deleteNode`define how nodes are added to and deleted from the model opened in the editor.
+This includes notifying the tree which nodes it has to add resp. remove.
+
+Furthermore, you need to implement `handleFormUpdate` to handle updating a tree node with new data.
+
+`save` needs to be implemented if the tree editor should react to the common save command (e.g. if the user presses Ctrl+S in Theia).
+
+## JsonFormsTree.LabelProvider
+Implementing this specifies how the editor's tree derives nodes' names from their data.
+
+## JsonFormsTree.NodeFactory
+Implementing this specifies how tree nodes are created from instance data.
+
+# Registering the custom tree editor
+To use the editor, you need to bind it in your frontend module (which exports a `ContainerModule`).
+However, you should not bind your implementations directly to the interfaces provided
+by the json forms tree package because this creates conflicts when when using multiple tree editor implementations in the same Theia instance.
+
+Instead, your tree editor implementation's symbol should be bound to a dynamic value
+which creates the editor within an encapsulated child context.
+This child context also needs to contain the `JsonFormsTreeWidget` used by the editor to render the tree.
+For this, you should use the utility function `createJsonFormsTreeWidget`.
+Such a registration could look like this:
+
+```typescript
+bind<WidgetFactory>(WidgetFactory).toDynamicValue(context => ({
+  id: CoffeeTreeEditorWidget.WIDGET_ID,
+  createWidget: (options: NavigatableWidgetOptions) => {
+    const { container } = context;
+    const child = container.createChild();
+
+    // Create and bind tree widget only for this editor creation
+    const tree = createJsonFormsTreeWidget(context.container, CoffeeTreeLabelProvider, CoffeeTreeNodeFactory);
+    child.bind(JsonFormsTreeWidget).toConstantValue(tree);
+
+    // Create and bind tree editor options
+    const uri = new URI(options.uri);
+    child
+      .bind<JsonFormsTreeEditorWidgetOptions>(
+        JsonFormsTreeEditorWidgetOptions
+      )
+      .toConstantValue({
+        uri: uri
+      });
+
+    return child.get(CoffeeTreeEditorWidget);
+  }
+}));
+```
+
+## Binding for use outside the tree editor widget
+If you need to use your implementations of `JsonFormsTree.NodeFactory` or `JsonFormsTree.LabelProvider`,
+you have two methods to register them safely.
+
+First, you can bind them to themselves. Then you can get them injected by referencing your implementation directly.
+Bind like this:
+```typescript
+bind(CustomTreeNodeFactory).toSelf();
+```
+And inject likes this (e.g. in a constructor):
+```typescript
+@inject(CustomTreeNodeFactory) factory: CustomTreeNodeFactory
+```
+
+The second method is to bind an implementation to a name and add a name constraint to it.
+```typescript
+bind(CustomTreeNodeFactory).to(JsonFormsTree.NodeFactory).whenTargetNamed("custom-tree");
+```
+And inject likes this (e.g. in a constructor):
+```typescript
+@inject(JsonFormsTree.NodeFactory) @named("custom-tree") factory: JsonFormsTree.NodeFactor
+```

--- a/web/jsonforms-tree/package.json
+++ b/web/jsonforms-tree/package.json
@@ -9,7 +9,6 @@
     "@jsonforms/core": "2.3.1",
     "@jsonforms/react": "2.3.1",
     "@jsonforms/material-renderers": "2.3.1",
-    "@modelserver/theia": "next",
     "@material-ui/core": "^4.3.0",
     "@material-ui/icons": "^4.2.0",
     "@theia/core": "0.7.1",

--- a/web/jsonforms-tree/src/browser/editor/json-forms-tree-editor-widget.tsx
+++ b/web/jsonforms-tree/src/browser/editor/json-forms-tree-editor-widget.tsx
@@ -13,8 +13,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-import { ModelServerReferenceDescription } from '@modelserver/theia/lib/common';
-import { BaseWidget, Message, Navigatable, Saveable, SplitPanel, TreeNode, Widget } from '@theia/core/lib/browser';
+import { BaseWidget, Message, Navigatable, Saveable, SplitPanel, Widget } from '@theia/core/lib/browser';
 import { Emitter, Event, ILogger } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
@@ -73,8 +72,7 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
         ) {
           return;
         }
-        const node = this.getNodeDescription(this.selectedNode);
-        this.handleFormUpdate(data, node);
+        this.handleFormUpdate(data, this.selectedNode);
       }, 250)
     );
     this.toDispose.push(
@@ -132,30 +130,7 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
     }
     this.update();
   }
-  protected getNodeDescription(
-    node: JsonFormsTree.Node
-  ): ModelServerReferenceDescription {
-    const getRefSegment = (n: JsonFormsTree.Node) =>
-      n.jsonforms.property
-        ? `@${n.jsonforms.property}` +
-          (n.jsonforms.index ? `.${n.jsonforms.index}` : '')
-        : '';
-    let refToNode = '';
-    let toCheck: TreeNode = node;
-    while (toCheck && JsonFormsTree.Node.is(toCheck)) {
-      const parentRefSeg = getRefSegment(toCheck);
-      refToNode =
-        parentRefSeg === '' ? refToNode : '/' + parentRefSeg + refToNode;
-      toCheck = toCheck.parent;
-    }
-    const ownerRef = `${
-      this.workspaceService.workspace.uri
-    }/${this.getModelIDToRequest()}#/${refToNode}`;
-    return {
-      eClass: node.jsonforms.type,
-      $ref: ownerRef.replace('file:///', 'file:/')
-    };
-  }
+
   protected abstract deleteNode(node: Readonly<JsonFormsTree.Node>): void;
   protected abstract addNode({
     node,
@@ -177,9 +152,16 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
       this.splitPanel.node.focus();
     }
   }
+
+  /**
+   * Updates the data of a tree node.
+   *
+   * @param data The new data for the node
+   * @param node The tree node whose data will be updated
+   */
   protected abstract handleFormUpdate(
     data: any,
-    node: ModelServerReferenceDescription
+    node: JsonFormsTree.Node
   ): void;
 
   public save(): void {

--- a/web/jsonforms-tree/src/browser/editor/json-forms-tree-editor-widget.tsx
+++ b/web/jsonforms-tree/src/browser/editor/json-forms-tree-editor-widget.tsx
@@ -134,7 +134,7 @@ export abstract class JsonFormsTreeEditorWidget extends BaseWidget
   protected abstract deleteNode(node: Readonly<JsonFormsTree.Node>): void;
   protected abstract addNode({
     node,
-    eClass,
+    type,
     property
   }: AddCommandProperty): void;
 

--- a/web/jsonforms-tree/src/browser/tree/json-forms-tree-widget.tsx
+++ b/web/jsonforms-tree/src/browser/tree/json-forms-tree-widget.tsx
@@ -27,7 +27,7 @@ import { JsonFormsTree } from './json-forms-tree';
 export interface AddCommandProperty {
   node: JsonFormsTree.Node,
   property: string,
-  eClass: string
+  type: string
 }
 
 export interface JsonFormsTreeAnchor {
@@ -160,7 +160,7 @@ export class JsonFormsTreeWidget extends TreeWidget {
 
   private createAddHandler(node: JsonFormsTree.Node): (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void {
     return event => {
-      const addHandler = (property: string, eClass: string) => this.onAddEmitter.fire({ node, property, eClass });
+      const addHandler = (property: string, eClass: string) => this.onAddEmitter.fire({ node, property, type: eClass });
       const treeAnchor: JsonFormsTreeAnchor = {
         x: event.nativeEvent.x,
         y: event.nativeEvent.y,

--- a/web/jsonforms-tree/src/browser/tree/json-forms-tree-widget.tsx
+++ b/web/jsonforms-tree/src/browser/tree/json-forms-tree-widget.tsx
@@ -13,7 +13,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
-import { ModelServerObject } from '@modelserver/theia';
 import { Emitter, MenuPath } from '@theia/core';
 import { ConfirmDialog, ExpandableTreeNode, TreeModel } from '@theia/core/lib/browser';
 import { ContextMenuRenderer } from '@theia/core/lib/browser/context-menu-renderer';
@@ -279,13 +278,20 @@ export class JsonFormsTreeWidget extends TreeWidget {
     this.model.refresh();
   }
 
-  public addChildren(node: JsonFormsTree.Node, data: ModelServerObject[], property: string) {
+  /**
+   * Creates new tree nodes for the given data and adds them to the given node.
+   *
+   * @param node The node to add children to
+   * @param data The data array to generate the new tree nodes from
+   * @param property The property of the parent data which will contain the new nodes.
+   */
+  public addChildren(node: JsonFormsTree.Node, data: any[], property: string) {
     const currentValue = node.jsonforms.data[property];
     let index = 0;
     if (Array.isArray(currentValue)) {
       index = currentValue.length;
     }
-    data.map((d, i) => this.nodeFactory.mapData(d, node, property, d.eClass, index + i));
+    data.map((d, i) => this.nodeFactory.mapData(d, node, property, index + i));
     this.updateIndex(node, property);
     this.model.refresh();
   }

--- a/web/jsonforms-tree/src/browser/tree/json-forms-tree.ts
+++ b/web/jsonforms-tree/src/browser/tree/json-forms-tree.ts
@@ -67,17 +67,15 @@ export namespace JsonFormsTree {
     /**
      * Creates the corresponding TreeNode for the given data.
      *
-     * @param currentData The current instance data to map to a tree node
-     * @param parent This node's parent node
+     * @param data The instance data to map to a tree node
+     * @param parent The created node's parent node
      * @param property The JSON property which this node's data is contained in
-     * @param type The type of the node
      * @param index The index which this node's data is contained in the parent property
      */
     mapData(
-      currentData: any,
+      data: any,
       parent?: Node,
       property?: string,
-      eClass?: string,
       index?: number
     ): Node;
 

--- a/web/jsonforms-tree/src/browser/tree/json-forms-tree.ts
+++ b/web/jsonforms-tree/src/browser/tree/json-forms-tree.ts
@@ -70,13 +70,14 @@ export namespace JsonFormsTree {
      * @param data The instance data to map to a tree node
      * @param parent The created node's parent node
      * @param property The JSON property which this node's data is contained in
-     * @param index The index which this node's data is contained in the parent property
+     * @param indexOrKey If the data is inserted in an array property, this is the index it is inserted at.
+     *                   If the data is inserted into an object, this is the key the data is associated with.
      */
     mapData(
       data: any,
       parent?: Node,
       property?: string,
-      index?: number
+      indexOrKey?: number | string
     ): Node;
 
     /**

--- a/web/jsonforms-tree/src/browser/util.ts
+++ b/web/jsonforms-tree/src/browser/util.ts
@@ -18,10 +18,19 @@ import { createTreeContainer, defaultTreeProps, TreeProps, TreeWidget } from '@t
 import { Container, interfaces } from 'inversify';
 
 import { ChildrenDescriptor, ModelService } from './model-service';
+import { JsonFormsTree } from './tree/json-forms-tree';
 import { JsonFormsTreeContextMenu, JsonFormsTreeWidget } from './tree/json-forms-tree-widget';
 
-function createJsonFormsTreeContainer(parent: interfaces.Container): Container {
+function createJsonFormsTreeContainer(
+    parent: interfaces.Container,
+    labelProvider: interfaces.Newable<JsonFormsTree.LabelProvider>,
+    nodeFactory: interfaces.Newable<JsonFormsTree.NodeFactory>
+): Container {
     const child = createTreeContainer(parent);
+
+    // bind the given label provider and node factory in the child container to inject them into the tree
+    child.bind(JsonFormsTree.LabelProvider).to(labelProvider);
+    child.bind(JsonFormsTree.NodeFactory).to(nodeFactory);
 
     child.unbind(TreeWidget);
     child.bind(JsonFormsTreeWidget).toSelf();
@@ -37,9 +46,11 @@ export const JSON_FORMS_TREE_PROPS = <TreeProps>{
 };
 
 export function createJsonFormsTreeWidget(
-    parent: interfaces.Container
+    parent: interfaces.Container,
+    labelProvider: interfaces.Newable<JsonFormsTree.LabelProvider>,
+    nodeFactory: interfaces.Newable<JsonFormsTree.NodeFactory>
 ): JsonFormsTreeWidget {
-    return createJsonFormsTreeContainer(parent).get(JsonFormsTreeWidget);
+    return createJsonFormsTreeContainer(parent, labelProvider, nodeFactory).get(JsonFormsTreeWidget);
 }
 
 export function generateAddCommands(modelService: ModelService): Map<string, Map<string, Command>> {


### PR DESCRIPTION
## JsonFormsTreeWidget
* The `addChildren` method now gets the new data as an any array instead of a `ModelServerObject` array. This works because the data is internally delegated to the node factory which is custom for every tree implementation.
* Rename property `eClass` of interface `AddCommandProperty` to `type`.

## JsonFormsTreeEditorWidget
* Remove method `getNodeDescription` as it only contained model server specific code. This is moved down to the coffee editor tree editor widget.
* `handleFormUpdate` now takes the updated tree node instead of the model server reference.

## JsonFormsTree.NodeFactory
* Remove `eClass` parameter. If needed, implementations should determine this from the data
* Rename parameter `currentData` to `data`

**Also adapt the coffee editor implementations to these changes.**