### PR TITLE
Add window.onbeforeunload listener to tree editor

### DIFF
--- a/web/coffee-editor-extension/src/browser/coffee-tree/coffee-tree-editor-widget.tsx
+++ b/web/coffee-editor-extension/src/browser/coffee-tree/coffee-tree-editor-widget.tsx
@@ -171,6 +171,8 @@ export class CoffeeTreeEditorWidget extends NavigatableTreeEditorWidget {
       return;
     });
     this.modelServerApi.subscribe(this.getModelIDToRequest());
+    // see https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
+    window.onbeforeunload = () => this.dispose();
   }
   private getOldSelectedPath(): string[] {
     const paths: string[] = [];


### PR DESCRIPTION
By adding the window.onbeforeunload listener, the tree can be disposed when the page is reloaded.

Fix #208